### PR TITLE
Fix wrogn URL for GetPosition API call

### DIFF
--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -113,7 +113,7 @@ func (c *Client) ListPositions() ([]Position, error) {
 // GetPosition returns the account's position for the
 // provided symbol.
 func (c *Client) GetPosition(symbol string) (*Position, error) {
-	u, err := url.Parse("%s/v1/positions")
+	u, err := url.Parse(fmt.Sprintf("%s/v1/positions", base))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It seems there is missing `base` URL for `GetPosition` for rest client