### PR TITLE
polygon.io /exchanges endpoint

### DIFF
--- a/polygon/entities.go
+++ b/polygon/entities.go
@@ -162,3 +162,13 @@ type StreamAggregate struct {
 	StartTimestamp    int64   `json:"s"`
 	EndTimestamp      int64   `json:"e"`
 }
+
+// Exchange defines the Stocks / Equities "Exchange" endpoint response
+type StockExchange struct {
+	Id     int64  `json:"id"`
+	Type   string `json:"type"`
+	Market string `json:"market"`
+	Mic    string `json:"mic"`
+	Name   string `json:"name"`
+	Tape   string `json:"tape"`
+}

--- a/polygon/polygon_test.go
+++ b/polygon/polygon_test.go
@@ -97,6 +97,29 @@ func (s *PolygonTestSuite) TestPolygon() {
 		assert.NotNil(s.T(), err)
 		assert.Nil(s.T(), resp)
 	}
+
+	// get exchange data
+	{
+		// successful
+		get = func(u *url.URL) (*http.Response, error) {
+			return &http.Response{
+				Body: genBody([]byte(exchangeBody)),
+			}, nil
+		}
+
+		resp, err := GetStockExchanges()
+		assert.Nil(s.T(), err)
+		assert.NotNil(s.T(), resp)
+
+		// api failure
+		get = func(u *url.URL) (*http.Response, error) {
+			return &http.Response{}, fmt.Errorf("fail")
+		}
+
+		resp, err = GetStockExchanges()
+		assert.NotNil(s.T(), err)
+		assert.Nil(s.T(), resp)
+	}
 }
 
 type nopCloser struct {
@@ -190,4 +213,38 @@ const (
 		],
 		"type": "trades"
 	}`
+	exchangeBody = `[
+		{
+		  "id": 1,
+		  "type": "exchange",
+		  "market": "equities",
+		  "mic": "XASE",
+		  "name": "NYSE American (AMEX)",
+		  "tape": "A"
+		},
+		{
+		  "id": 2,
+		  "type": "exchange",
+		  "market": "equities",
+		  "mic": "XBOS",
+		  "name": "NASDAQ OMX BX",
+		  "tape": "B"
+		},
+		{
+		  "id": 15,
+		  "type": "exchange",
+		  "market": "equities",
+		  "mic": "IEXG",
+		  "name": "IEX",
+		  "tape": "V"
+		},
+		{
+		  "id": 16,
+		  "type": "TRF",
+		  "market": "equities",
+		  "mic": "XCBO",
+		  "name": "Chicago Board Options Exchange",
+		  "tape": "W"
+		}
+	  ]`
 )

--- a/polygon/rest.go
+++ b/polygon/rest.go
@@ -206,8 +206,8 @@ func (c *Client) GetHistoricQuotes(symbol, date string) (totalQuotes *HistoricQu
 	return totalQuotes, nil
 }
 
-// GetStockExchanges
-func (c *Client) GetStockExchanges() (exchanges *[]StockExchange, err error) {
+// GetStockExchanges requests available stock and equity exchanges on polygon.io
+func (c *Client) GetStockExchanges() ([]StockExchange, error) {
 	u, err := url.Parse(fmt.Sprintf(exchangeURL, base))
 	if err != nil {
 		return nil, err
@@ -227,9 +227,8 @@ func (c *Client) GetStockExchanges() (exchanges *[]StockExchange, err error) {
 		return nil, fmt.Errorf("status code %v", resp.StatusCode)
 	}
 
-	// exchanges := &[]StockExchange{}
-
-	if err = unmarshal(resp, exchanges); err != nil {
+	var exchanges []StockExchange
+	if err = unmarshal(resp, &exchanges); err != nil {
 		return nil, err
 	}
 
@@ -258,6 +257,12 @@ func GetHistoricTrades(symbol, date string) (totalTrades *HistoricTrades, err er
 // on the provided date using the default Polygon client.
 func GetHistoricQuotes(symbol, date string) (totalQuotes *HistoricQuotes, err error) {
 	return DefaultClient.GetHistoricQuotes(symbol, date)
+}
+
+// GetStockExchanges queries Polygon.io REST API for information on available
+// stock and equities exchanges
+func GetStockExchanges() ([]StockExchange, error) {
+	return DefaultClient.GetStockExchanges()
 }
 
 func unmarshal(resp *http.Response, data interface{}) error {

--- a/polygon/rest.go
+++ b/polygon/rest.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	aggURL    = "%v/v1/historic/agg/%v/%v"
-	tradesURL = "%v/v1/historic/trades/%v/%v"
-	quotesURL = "%v/v1/historic/quotes/%v/%v"
+	aggURL      = "%v/v1/historic/agg/%v/%v"
+	tradesURL   = "%v/v1/historic/trades/%v/%v"
+	quotesURL   = "%v/v1/historic/quotes/%v/%v"
+	exchangeURL = "%v/v1/meta/exchanges"
 )
 
 var (
@@ -203,6 +204,37 @@ func (c *Client) GetHistoricQuotes(symbol, date string) (totalQuotes *HistoricQu
 	}
 
 	return totalQuotes, nil
+}
+
+// GetStockExchanges
+func (c *Client) GetStockExchanges() (exchanges *[]StockExchange, err error) {
+	u, err := url.Parse(fmt.Sprintf(exchangeURL, base))
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	q.Set("apiKey", c.credentials.ID)
+
+	u.RawQuery = q.Encode()
+
+	resp, err := get(u)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("status code %v", resp.StatusCode)
+	}
+
+	// exchanges := &[]StockExchange{}
+
+	if err = unmarshal(resp, exchanges); err != nil {
+		return nil, err
+	}
+
+	return exchanges, nil
+
 }
 
 // GetHistoricAggregates requests polygon's REST API for historic aggregates


### PR DESCRIPTION
I added the ability for a client to request the /exchanges REST endpoint. This lets a client decode the 'Exchange' field in TradeStream messages to a human readable exchange name.