### PR TITLE
Add v2 aggregates to Polygon REST API

### DIFF
--- a/polygon/entities.go
+++ b/polygon/entities.go
@@ -84,7 +84,7 @@ type QuoteTick struct {
 }
 
 // HistoricAggregates is the structure that defines
-// aggregate data served through polygon's REST API.
+// aggregate data served through Polygon's v1 REST API.
 type HistoricAggregates struct {
 	Symbol        string  `json:"symbol"`
 	AggregateType AggType `json:"aggType"`
@@ -99,6 +99,16 @@ type HistoricAggregates struct {
 	Ticks []AggTick `json:"ticks"`
 }
 
+// V2HistoricAggregates is the structure that defines
+// aggregate data served through Polygon's v2 REST API.
+type HistoricAggregatesV2 struct {
+	Symbol        string  `json:"ticker"`
+	Adjusted      bool `json:"adjusted"`
+	QueryCount    int `json:"queryCount"`
+	ResultsCount  int `json:"resultsCount"`
+	Ticks         []AggTick `json:"results"`
+}
+
 // AggTick is the structure that contains the actual
 // tick data included in a HistoricAggregates response
 type AggTick struct {
@@ -106,8 +116,9 @@ type AggTick struct {
 	High              float64 `json:"h"`
 	Low               float64 `json:"l"`
 	Close             float64 `json:"c"`
-	Volume            int     `json:"v"`
+	Volume            float64 `json:"v"`
 	EpochMilliseconds int64   `json:"t"`
+	Items             int64   `json:"n"` // v2 response only
 }
 
 // AggType used in the HistoricAggregates response

--- a/polygon/entities.go
+++ b/polygon/entities.go
@@ -102,11 +102,11 @@ type HistoricAggregates struct {
 // V2HistoricAggregates is the structure that defines
 // aggregate data served through Polygon's v2 REST API.
 type HistoricAggregatesV2 struct {
-	Symbol        string  `json:"ticker"`
-	Adjusted      bool `json:"adjusted"`
-	QueryCount    int `json:"queryCount"`
-	ResultsCount  int `json:"resultsCount"`
-	Ticks         []AggTick `json:"results"`
+	Symbol       string    `json:"ticker"`
+	Adjusted     bool      `json:"adjusted"`
+	QueryCount   int       `json:"queryCount"`
+	ResultsCount int       `json:"resultsCount"`
+	Ticks        []AggTick `json:"results"`
 }
 
 // AggTick is the structure that contains the actual

--- a/polygon/rest.go
+++ b/polygon/rest.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	aggURL      = "%v/v1/historic/agg/%v/%v"
-	aggv2URL	= "%v/v2/aggs/ticker/%v/range/%v/%v/%v/%v"
+	aggv2URL    = "%v/v2/aggs/ticker/%v/range/%v/%v/%v/%v"
 	tradesURL   = "%v/v1/historic/trades/%v/%v"
 	quotesURL   = "%v/v1/historic/quotes/%v/%v"
 	exchangeURL = "%v/v1/meta/exchanges"
@@ -106,7 +106,7 @@ func (c *Client) GetHistoricAggregatesV2(
 	from, to *time.Time,
 	unadjusted *bool) (*HistoricAggregatesV2, error) {
 
-	u, err := url.Parse(fmt.Sprintf(aggv2URL, base, symbol, multiplier, resolution, from.Unix() * 1000, to.Unix() * 1000))
+	u, err := url.Parse(fmt.Sprintf(aggv2URL, base, symbol, multiplier, resolution, from.Unix()*1000, to.Unix()*1000))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change adds the new Polygon v2 aggregate method, which is reportedly more stable than its v1 counterpart. It also changes the type of the `volume` field in AggTick from int to float, as calls for AAPL aggregates were failing on day-length timeframes.