### PR TITLE
Remove deprecated Quotes data endpoints

### DIFF
--- a/alpaca/alpaca_test.go
+++ b/alpaca/alpaca_test.go
@@ -383,55 +383,6 @@ func (s *AlpacaTestSuite) TestAlpaca() {
 		assert.Nil(s.T(), bars)
 	}
 
-	// list quotes
-	{
-		// successful
-		do = func(c *Client, req *http.Request) (*http.Response, error) {
-			quotes := []Quote{{AssetID: "some_id"}}
-			return &http.Response{
-				Body: genBody(quotes),
-			}, nil
-		}
-
-		quotes, err := ListQuotes([]string{"APCA"})
-		assert.Nil(s.T(), err)
-		require.Len(s.T(), quotes, 1)
-		assert.Equal(s.T(), "some_id", quotes[0].AssetID)
-
-		// api failure
-		do = func(c *Client, req *http.Request) (*http.Response, error) {
-			return &http.Response{}, fmt.Errorf("fail")
-		}
-
-		quotes, err = ListQuotes([]string{"APCA"})
-		assert.NotNil(s.T(), err)
-		assert.Nil(s.T(), quotes)
-	}
-
-	// get quote
-	{
-		// successful
-		do = func(c *Client, req *http.Request) (*http.Response, error) {
-			quote := Quote{AssetID: "some_id"}
-			return &http.Response{
-				Body: genBody(quote),
-			}, nil
-		}
-
-		quote, err := GetQuote("APCA")
-		assert.Nil(s.T(), err)
-		assert.NotNil(s.T(), quote)
-
-		// api failure
-		do = func(c *Client, req *http.Request) (*http.Response, error) {
-			return &http.Response{}, fmt.Errorf("fail")
-		}
-
-		quote, err = GetQuote("APCA")
-		assert.NotNil(s.T(), err)
-		assert.Nil(s.T(), quote)
-	}
-
 	// test verify
 	{
 		// 200

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -394,52 +394,6 @@ func (c *Client) GetSymbolBars(symbol string, opts ListBarParams) ([]Bar, error)
 	return barsMap[symbol], nil
 }
 
-// ListQuotes returns a list of quotes corresponding to the
-// provided list of symbols.
-func (c *Client) ListQuotes(symbols []string) ([]Quote, error) {
-	vals := url.Values{}
-	vals.Add("symbols", strings.Join(symbols, ","))
-
-	u, err := url.Parse(fmt.Sprintf("%v/v1/quotes?%v", base, vals.Encode()))
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.get(u)
-	if err != nil {
-		return nil, err
-	}
-
-	quotes := []Quote{}
-
-	if err = unmarshal(resp, &quotes); err != nil {
-		return nil, err
-	}
-
-	return quotes, nil
-}
-
-// GetQuote returns a quote corresponding to the provided symbol.
-func (c *Client) GetQuote(symbol string) (*Quote, error) {
-	u, err := url.Parse(fmt.Sprintf("%v/v1/assets/%s/quote", base, symbol))
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.get(u)
-	if err != nil {
-		return nil, err
-	}
-
-	quote := &Quote{}
-
-	if err = unmarshal(resp, quote); err != nil {
-		return nil, err
-	}
-
-	return quote, nil
-}
-
 // GetAccount returns the user's account information
 // using the default Alpaca client.
 func GetAccount() (*Account, error) {
@@ -519,18 +473,6 @@ func ListBars(symbols []string, opts ListBarParams) (map[string][]Bar, error) {
 // Alpaca client.
 func GetSymbolBars(symbol string, opts ListBarParams) ([]Bar, error) {
 	return DefaultClient.GetSymbolBars(symbol, opts)
-}
-
-// ListQuotes returns a list of quotes corresponding to the
-// provided list of symbols with the default Alpaca client.
-func ListQuotes(symbols []string) ([]Quote, error) {
-	return DefaultClient.ListQuotes(symbols)
-}
-
-// GetQuote returns a quote corresponding to the provided symbol
-// with the default Alpaca client.
-func GetQuote(symbol string) (*Quote, error) {
-	return DefaultClient.GetQuote(symbol)
 }
 
 func (c *Client) get(u *url.URL) (*http.Response, error) {


### PR DESCRIPTION
As issue #19 points out, quotes have been removed from Alpaca's data API. This removes them from the SDK.