### PR TITLE
Allow for options to be set

### DIFF
--- a/common/options.go
+++ b/common/options.go
@@ -1,0 +1,7 @@
+package common
+
+// Options provides arguments available to various REST endpoints.
+type Options struct {
+	Offset int64
+	Limit  int
+}

--- a/polygon/polygon_test.go
+++ b/polygon/polygon_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alpacahq/alpaca-trade-api-go/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -59,7 +60,7 @@ func (s *PolygonTestSuite) TestPolygon() {
 
 		date := "2018-01-03"
 
-		resp, err := GetHistoricTrades("APCA", date)
+		resp, err := GetHistoricTrades("APCA", date, common.Options{Offset: 0})
 		assert.Nil(s.T(), err)
 		assert.NotNil(s.T(), resp)
 
@@ -68,7 +69,7 @@ func (s *PolygonTestSuite) TestPolygon() {
 			return &http.Response{}, fmt.Errorf("fail")
 		}
 
-		resp, err = GetHistoricTrades("APCA", date)
+		resp, err = GetHistoricTrades("APCA", date, common.Options{Offset: 0})
 		assert.NotNil(s.T(), err)
 		assert.Nil(s.T(), resp)
 	}

--- a/polygon/rest.go
+++ b/polygon/rest.go
@@ -140,8 +140,13 @@ func (c *Client) GetHistoricAggregatesV2(
 
 // GetHistoricTrades requests polygon's REST API for historic trades
 // on the provided date .
-func (c *Client) GetHistoricTrades(symbol, date string) (totalTrades *HistoricTrades, err error) {
-	offset := int64(0)
+func (c *Client) GetHistoricTrades(symbol, date string, options common.Options) (totalTrades *HistoricTrades, err error) {
+	offset := options.Offset
+	limit := options.Limit
+	if limit < 0 || limit > 50000 {
+		limit = 10000
+	}
+
 	for {
 		u, err := url.Parse(fmt.Sprintf(tradesURL, base, symbol, date))
 		if err != nil {
@@ -291,8 +296,8 @@ func GetHistoricAggregates(
 
 // GetHistoricTrades requests polygon's REST API for historic trades
 // on the provided date using the default Polygon client.
-func GetHistoricTrades(symbol, date string) (totalTrades *HistoricTrades, err error) {
-	return DefaultClient.GetHistoricTrades(symbol, date)
+func GetHistoricTrades(symbol, date string, options common.Options) (totalTrades *HistoricTrades, err error) {
+	return DefaultClient.GetHistoricTrades(symbol, date, options)
 }
 
 // GetHistoricQuotes requests polygon's REST API for historic quotes


### PR DESCRIPTION
For `GetHistoricTrades`, I found the need to provide a starting offset, but the client doesn't let me do so.

I took a rough crack at what that implementation might look like in the form of a new argument. Happy to take suggestions on other implementations, as well as applying this argument to any other method calls that take additional parameters.