### PR TITLE
Specify client in GetSymbolBars

### DIFF
--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -394,7 +394,7 @@ func (c *Client) ListBars(symbols []string, opts ListBarParams) (map[string][]Ba
 func (c *Client) GetSymbolBars(symbol string, opts ListBarParams) ([]Bar, error) {
 	symbolList := []string{symbol}
 
-	barsMap, err := ListBars(symbolList, opts)
+	barsMap, err := c.ListBars(symbolList, opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Specify the client when calling ListBars in GetSymbolBars to prevent fallback to the default client, which may cause unpredictable behavior/errors