### PR TITLE
Switch Polygon streaming from NATS to Websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,44 +53,42 @@ The SDK provides a unified streaming interface for both Polygon data updates, an
 Please note that running this example as-is requires that you have a funded Alpaca brokerage account, as that is necessary for access to Polygon's API.
 
 ```go
-import (
-    "os"
-    "fmt"
+package main
 
-    "github.com/alpacahq/alpaca-trade-api-go/alpaca"
-    "github.com/alpacahq/alpaca-trade-api-go/polygon"
-    "github.com/alpacahq/alpaca-trade-api-go/stream"
-    nats "github.com/nats-io/nats.go"
+import (
+	"fmt"
+	"os"
+
+	"github.com/alpacahq/alpaca-trade-api-go/alpaca"
+	"github.com/alpacahq/alpaca-trade-api-go/common"
+	"github.com/alpacahq/alpaca-trade-api-go/polygon"
+	"github.com/alpacahq/alpaca-trade-api-go/stream"
 )
 
 func main() {
-    os.Setenv(common.EnvApiKeyID, "<key_id>")
-    os.Setenv(common.EnvApiSecretKey, "<secret_key>")
+	os.Setenv(common.EnvApiKeyID, "your_key_id")
+	os.Setenv(common.EnvApiSecretKey, "your_secret_key")
 
-    if err := stream.Register(alpaca.TradeUpdates, tradeHandler); err != nil {
-        panic(err)
-    }
+	if err := stream.Register(alpaca.TradeUpdates, tradeHandler); err != nil {
+		panic(err)
+	}
 
-    if err := stream.Register("Q.AAPL", quoteHandler); err != nil {
-        panic(err)
-    }
+	if err := stream.Register("Q.AAPL", quoteHandler); err != nil {
+		panic(err)
+	}
 
-    select{}
+	select {}
 }
 
 func tradeHandler(msg interface{}) {
-    tradeupdate := msg.(alpaca.TradeUpdate)
-    fmt.Printf("%s event received for order %s.\n", tradeupdate.Event, tradeupdate.Order.ID)
+	tradeupdate := msg.(alpaca.TradeUpdate)
+	fmt.Printf("%s event received for order %s.\n", tradeupdate.Event, tradeupdate.Order.ID)
 }
 
 func quoteHandler(msg interface{}) {
-    quote := polygon.StreamQuote{}
+	quote := msg.(polygon.StreamQuote)
 
-    if err := json.Unmarshal(msg.(*nats.Msg).Data, &quote); err != nil {
-        panic(err)
-    }
-
-    fmt.Println(quote.Symbol, quote.BidPrice, quote.BidSize, quote.AskPrice, quote.AskSize)
+	fmt.Println(quote.Symbol, quote.BidPrice, quote.BidSize, quote.AskPrice, quote.AskSize)
 }
 ```
 

--- a/polygon/entities.go
+++ b/polygon/entities.go
@@ -156,7 +156,7 @@ type PolgyonServerMsg struct {
 }
 
 // StreamTrade is the structure that defines a trade that
-// polygon transmits via NATS protocol.
+// polygon transmits via websocket protocol.
 type StreamTrade struct {
 	Symbol     string  `json:"sym"`
 	Exchange   int     `json:"x"`
@@ -167,7 +167,7 @@ type StreamTrade struct {
 }
 
 // StreamQuote is the structure that defines a quote that
-// polygon transmits via NATS protocol.
+// polygon transmits via websocket protocol.
 type StreamQuote struct {
 	Symbol      string  `json:"sym"`
 	Condition   int     `json:"c"`
@@ -181,7 +181,7 @@ type StreamQuote struct {
 }
 
 // StreamAggregate is the structure that defines an aggregate that
-// polygon transmits via NATS protocol.
+// polygon transmits via websocket protocol.
 type StreamAggregate struct {
 	Event             string  `json:"ev"`
 	Symbol            string  `json:"sym"`

--- a/polygon/entities.go
+++ b/polygon/entities.go
@@ -136,6 +136,25 @@ const (
 	Day AggType = "day"
 )
 
+// polygon stream
+
+// PolygonClientMsg is the standard message sent by clients of the stream interface
+type PolygonClientMsg struct {
+	Action string `json:"action"`
+	Params string `json:"params"`
+}
+
+type PolygonAuthMsg struct {
+	Event   string `json:"ev"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+// PolygonServerMsg contains the field that is present in all responses to identify their type
+type PolgyonServerMsg struct {
+	Event string `json:"ev"`
+}
+
 // StreamTrade is the structure that defines a trade that
 // polygon transmits via NATS protocol.
 type StreamTrade struct {

--- a/polygon/stream.go
+++ b/polygon/stream.go
@@ -1,56 +1,227 @@
 package polygon
 
 import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
 	"os"
+	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/alpacahq/alpaca-trade-api-go/common"
-	nats "github.com/nats-io/nats.go"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	MinuteAggs = "AM"
+	SecondAggs = "A"
+	Trades     = "T"
+	Quotes     = "Q"
 )
 
 var (
-	servers string
-	str     *Stream
-	once    sync.Once
+	once sync.Once
+	str  *Stream
 )
 
 type Stream struct {
-	conn *nats.Conn
+	sync.Mutex
+	sync.Once
+	conn                  *websocket.Conn
+	authenticated, closed atomic.Value
+	handlers              sync.Map
 }
 
+// Subscribe to the specified Polygon stream channel.
+func (s *Stream) Subscribe(channel string, handler func(msg interface{})) (err error) {
+	if s.conn == nil {
+		s.conn = openSocket()
+	}
+
+	if err = s.auth(); err != nil {
+		return
+	}
+
+	s.Do(func() {
+		go s.start()
+	})
+
+	s.handlers.Store(channel, handler)
+
+	if err = s.sub(channel); err != nil {
+		return
+	}
+
+	return
+}
+
+// Close gracefully closes the Polygon stream.
+func (s *Stream) Close() error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.conn == nil {
+		return nil
+	}
+
+	if err := s.conn.WriteMessage(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+	); err != nil {
+		return err
+	}
+
+	// so we know it was gracefully closed
+	s.closed.Store(true)
+
+	return s.conn.Close()
+}
+
+func (s *Stream) handleError(err error) {
+	if websocket.IsCloseError(err) {
+		// if this was a graceful closure, don't reconnect
+		if s.closed.Load().(bool) {
+			return
+		}
+	} else {
+		log.Printf("polygon stream read error (%v)", err)
+	}
+
+	s.conn = openSocket()
+}
+
+func (s *Stream) start() {
+	for {
+		if _, bytes, err := s.conn.ReadMessage(); err == nil {
+			msgArray := []PolgyonServerMsg{}
+			if err := json.Unmarshal(bytes, msgArray); err == nil {
+				for _, msg := range msgArray {
+					if v, ok := s.handlers.Load(msg.Event); ok {
+						switch msg.Event {
+						case SecondAggs:
+							fallthrough
+						case MinuteAggs:
+							var minuteAgg StreamAggregate
+							if err := json.Unmarshal(bytes, minuteAgg); err == nil {
+								h := v.(func(msg interface{}))
+								h(minuteAgg)
+							} else {
+								s.handleError(err)
+							}
+						case Quotes:
+							var quoteUpdate StreamQuote
+							if err := json.Unmarshal(bytes, quoteUpdate); err == nil {
+								h := v.(func(msg interface{}))
+								h(quoteUpdate)
+							} else {
+								s.handleError(err)
+							}
+						case Trades:
+							var tradeUpdate StreamTrade
+							if err := json.Unmarshal(bytes, tradeUpdate); err == nil {
+								h := v.(func(msg interface{}))
+								h(tradeUpdate)
+							} else {
+								s.handleError(err)
+							}
+						}
+					}
+				}
+			} else {
+				s.handleError(err)
+			}
+		} else {
+			s.handleError(err)
+		}
+	}
+}
+
+func (s *Stream) sub(channel string) (err error) {
+	s.Lock()
+	defer s.Unlock()
+
+	subReq := PolygonClientMsg{
+		Action: "subscribe",
+		Params: channel,
+	}
+
+	if err = s.conn.WriteJSON(subReq); err != nil {
+		return
+	}
+
+	return
+}
+
+func (s *Stream) isAuthenticated() bool {
+	return s.authenticated.Load().(bool)
+}
+
+func (s *Stream) auth() (err error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.isAuthenticated() {
+		return
+	}
+
+	authRequest := PolygonClientMsg{
+		Action: "auth",
+		Params: common.Credentials().ID,
+	}
+
+	if err = s.conn.WriteJSON(authRequest); err != nil {
+		return
+	}
+
+	msg := PolygonAuthMsg{}
+
+	// ensure the auth response comes in a timely manner
+	s.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	defer s.conn.SetReadDeadline(time.Time{})
+
+	if err = s.conn.ReadJSON(&msg); err != nil {
+		return
+	}
+
+	if !strings.EqualFold(msg.Status, "success") {
+		return fmt.Errorf("failed to authorize alpaca stream")
+	}
+
+	return
+}
+
+// GetStream returns the singleton Polygon stream structure.
 func GetStream() *Stream {
 	once.Do(func() {
-		str = &Stream{}
+		str = &Stream{
+			authenticated: atomic.Value{},
+			handlers:      sync.Map{},
+		}
+
+		str.authenticated.Store(false)
+		str.closed.Store(false)
 	})
 
 	return str
 }
 
-// Subscribe to the specified NATS stream with the supplied handler
-func (s *Stream) Subscribe(channel string, handler func(msg interface{})) (err error) {
-	if s.conn == nil {
-		servers, ok := os.LookupEnv("POLYGON_NATS_SERVERS")
-		if !ok {
-			servers = "nats://nats1.polygon.io:31101, nats://nats2.polygon.io:31102, nats://nats3.polygon.io:31103"
-		}
-		c, err := nats.Connect(servers, nats.Token(common.Credentials().ID))
-		if err != nil {
-			return err
-		}
-		s.conn = c
+func openSocket() *websocket.Conn {
+	scheme := "wss"
+	polygonStreamEndpoint, ok := os.LookupEnv("POLYGON_WS_URL")
+	if !ok {
+		polygonStreamEndpoint = "alpaca.socket.polygon.io"
 	}
-
-	h := func(msg *nats.Msg) {
-		handler(msg)
+	ub, _ := url.Parse(polygonStreamEndpoint)
+	if ub.Scheme == "http" {
+		scheme = "ws"
 	}
-
-	_, err = s.conn.Subscribe(channel, h)
-
-	return
-}
-
-// Close the polygon NATS connection gracefully
-func (s *Stream) Close() error {
-	s.conn.Close()
-	return nil
+	u := url.URL{Scheme: scheme, Host: ub.Host, Path: "/stocks"}
+	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		panic(err)
+	}
+	return c
 }


### PR DESCRIPTION
Polygon's NATS socket is going to be deprecated at some point, so we're switching the stream connection used by the SDK to use Websockets instead. Necessary code changes should be minimal; you can see in the readme a new way to access the data objects in your handler methods.