### PR TITLE
Add alternative authentication via OAuth

### DIFF
--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -23,8 +23,12 @@ var (
 	dataUrl       = "https://data.alpaca.markets/"
 	apiVersion    = "v2"
 	do            = func(c *Client, req *http.Request) (*http.Response, error) {
-		req.Header.Set("APCA-API-KEY-ID", c.credentials.ID)
-		req.Header.Set("APCA-API-SECRET-KEY", c.credentials.Secret)
+		if c.credentials.OAuth != "" {
+			req.Header.Set("Authorization", "Bearer "+c.credentials.OAuth)
+		} else {
+			req.Header.Set("APCA-API-KEY-ID", c.credentials.ID)
+			req.Header.Set("APCA-API-SECRET-KEY", c.credentials.Secret)
+		}
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {

--- a/common/credentials.go
+++ b/common/credentials.go
@@ -13,11 +13,13 @@ var (
 const (
 	EnvApiKeyID     = "APCA_API_KEY_ID"
 	EnvApiSecretKey = "APCA_API_SECRET_KEY"
+	EnvApiOAuth     = "APCA_API_OAUTH"
 )
 
 type APIKey struct {
 	ID     string
 	Secret string
+	OAuth  string
 }
 
 // Credentials returns the user's Alpaca API key ID
@@ -26,5 +28,6 @@ func Credentials() *APIKey {
 	return &APIKey{
 		ID:     os.Getenv(EnvApiKeyID),
 		Secret: os.Getenv(EnvApiSecretKey),
+		OAuth:  os.Getenv(EnvApiOAuth),
 	}
 }


### PR DESCRIPTION
Alpaca will be adding support for OAuth authentication on a limited basis in the future. This adds the ability to configure an OAuth token via environment variable.