### PR TITLE
Attempt to reconnect on early closures

### DIFF
--- a/polygon/stream.go
+++ b/polygon/stream.go
@@ -245,15 +245,15 @@ func openSocket() *websocket.Conn {
 		c, _, err = websocket.DefaultDialer.Dial(polygonStreamEndpoint, nil)
 		// if the error is not nil...
 		if err != nil {
-			// try to reconnect up to 3 times
+			// try to reconnect up to 3 times if it's an abnormal closure
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
 				return (attempt < 3), err
-			} else { // otherwise crash
+			} else { // otherwise, crash
 				panic(err)
 			}
 		}
 		// no error, c connection is open
-		return (attempt < 3), err
+		return false, nil
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
I noted today that an early closure crash occurred after a `reconnect`, and during a new `open`:

```
A 2019-09-03T13:32:59Z Sep  3 13:32:59 instance-1 run.sh: 2019/09/03 13:32:59 polygon stream read error (websocket: close 1006 (abnormal closure): unexpected EOF) 
A 2019-09-03T13:32:59Z Sep  3 13:32:59 instance-1 startup-script: INFO startup-script: <13>Sep  3 13:32:59 run.sh: 2019/09/03 13:32:59 polygon stream read error (websocket: close 1006 (abnormal closure): unexpected EOF) 
A 2019-09-03T13:33:44Z Sep  3 13:33:44 instance-1 run.sh: panic: read tcp 10.150.0.3:37376->38.133.177.111:443: i/o timeout 
A 2019-09-03T13:33:44Z Sep  3 13:33:44 instance-1 run.sh:  
A 2019-09-03T13:33:44Z Sep  3 13:33:44 instance-1 run.sh: goroutine 46964 [running]: 
A 2019-09-03T13:33:44Z Sep  3 13:33:44 instance-1 run.sh: github.com/alpacahq/alpaca-trade-api-go/polygon.openSocket(0xc0003a6090) 
A 2019-09-03T13:33:44Z Sep  3 13:33:44 instance-1 run.sh: #011/home/gjtorikian/.gvm/pkgsets/go1.12.4/global/src/github.com/alpacahq/alpaca-trade-api-go/polygon/stream.go:243 +0x17b 
A 2019-09-03T13:33:44Z Sep  3 13:33:44 instance-1 run.sh: github.com/alpacahq/alpaca-trade-api-go/polygon.(*Stream).reconnect(0xc0003a6070) 
A 2019-09-03T13:33:44Z Sep  3 13:33:44 instance-1 run.sh: #011/home/gjtorikian/.gvm/pkgsets/go1.12.4/global/src/github.com/alpacahq/alpaca-trade-api-go/polygon/stream.go:85 +0x5c 
A 2019-09-03T13:33:44Z Sep  3 13:33:44 instance-1 run.sh: github.com/alpacahq/alpaca-trade-api-go/polygon.(*Stream).handleError(0xc0003a6070, 0x90a620, 0xbd52f0) 
A 2019-09-03T13:33:44Z Sep  3 13:33:44 instance-1 run.sh: #011/home/gjtorikian/.gvm/pkgsets/go1.12.4/global/src/github.com/alpacahq/alpaca-trade-api-go/polygon/stream.go:106 +0xa0 
```

The intent of this PR is to attempt to open a socket up to three times, before truly declaring the crash, using [`try.Do`](https://github.com/matryer/try#usage).