### PR TITLE
Add trade ID to streams

### DIFF
--- a/polygon/entities.go
+++ b/polygon/entities.go
@@ -160,6 +160,7 @@ type PolgyonServerMsg struct {
 type StreamTrade struct {
 	Symbol     string  `json:"sym"`
 	Exchange   int     `json:"x"`
+	TradeID    int64   `json:"i"`
 	Price      float64 `json:"p"`
 	Size       int64   `json:"s"`
 	Timestamp  int64   `json:"t"`


### PR DESCRIPTION
The [trade stream on Polygon](https://polygon.io/sockets) now provides a trade ID:

<img width="516" alt="image" src="https://user-images.githubusercontent.com/64050/65815047-01c42100-e1e2-11e9-8c35-76ae3ca0c27f.png">
