### PR TITLE
Remove excess print

### DIFF
--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -691,6 +691,5 @@ func unmarshal(resp *http.Response, data interface{}) error {
 		return err
 	}
 
-	fmt.Println()
 	return json.Unmarshal(body, data)
 }


### PR DESCRIPTION
As far as I can see, this has no bearing on the code, and instead prints out blank spaces.