### PR TITLE
Establish a separate Polygon API key

### DIFF
--- a/common/credentials.go
+++ b/common/credentials.go
@@ -14,20 +14,29 @@ const (
 	EnvApiKeyID     = "APCA_API_KEY_ID"
 	EnvApiSecretKey = "APCA_API_SECRET_KEY"
 	EnvApiOAuth     = "APCA_API_OAUTH"
+	EnvPolygonKeyID = "POLY_API_KEY_ID"
 )
 
 type APIKey struct {
-	ID     string
-	Secret string
-	OAuth  string
+	ID           string
+	Secret       string
+	OAuth        string
+	PolygonKeyID string
 }
 
 // Credentials returns the user's Alpaca API key ID
 // and secret for use through the SDK.
 func Credentials() *APIKey {
+	var polygonKeyID string
+	if s := os.Getenv(EnvPolygonKeyID); s != "" {
+		polygonKeyID = s
+	} else {
+		polygonKeyID = os.Getenv(EnvApiKeyID)
+	}
 	return &APIKey{
-		ID:     os.Getenv(EnvApiKeyID),
-		Secret: os.Getenv(EnvApiSecretKey),
-		OAuth:  os.Getenv(EnvApiOAuth),
+		ID:           os.Getenv(EnvApiKeyID),
+		PolygonKeyID: polygonKeyID,
+		Secret:       os.Getenv(EnvApiSecretKey),
+		OAuth:        os.Getenv(EnvApiOAuth),
 	}
 }

--- a/polygon/rest.go
+++ b/polygon/rest.go
@@ -77,7 +77,7 @@ func (c *Client) GetHistoricAggregates(
 	}
 
 	q := u.Query()
-	q.Set("apiKey", c.credentials.ID)
+	q.Set("apiKey", c.credentials.PolygonKeyID)
 
 	if from != nil {
 		q.Set("from", from.Format(time.RFC3339))
@@ -126,7 +126,7 @@ func (c *Client) GetHistoricAggregatesV2(
 	}
 
 	q := u.Query()
-	q.Set("apiKey", c.credentials.ID)
+	q.Set("apiKey", c.credentials.PolygonKeyID)
 
 	if unadjusted != nil {
 		q.Set("unadjusted", strconv.FormatBool(*unadjusted))
@@ -177,7 +177,7 @@ func (c *Client) GetHistoricTrades(
 		}
 
 		q := u.Query()
-		q.Set("apiKey", c.credentials.ID)
+		q.Set("apiKey", c.credentials.PolygonKeyID)
 		q.Set("limit", strconv.FormatInt(limit, 10))
 
 		if offset > 0 {
@@ -230,7 +230,7 @@ func (c *Client) GetHistoricTradesV2(ticker string, date string, opts *HistoricT
 	}
 
 	q := u.Query()
-	q.Set("apiKey", c.credentials.ID)
+	q.Set("apiKey", c.credentials.PolygonKeyID)
 	u.RawQuery = q.Encode()
 
 	resp, err := c.get(u, opts)
@@ -261,7 +261,7 @@ func (c *Client) GetHistoricQuotes(symbol, date string) (totalQuotes *HistoricQu
 		}
 
 		q := u.Query()
-		q.Set("apiKey", c.credentials.ID)
+		q.Set("apiKey", c.credentials.PolygonKeyID)
 		q.Set("limit", strconv.FormatInt(10000, 10))
 
 		if offset > 0 {
@@ -314,7 +314,7 @@ func (c *Client) GetHistoricQuotesV2(ticker string, date string, opts *HistoricT
 	}
 
 	q := u.Query()
-	q.Set("apiKey", c.credentials.ID)
+	q.Set("apiKey", c.credentials.PolygonKeyID)
 	u.RawQuery = q.Encode()
 
 	resp, err := c.get(u, opts)
@@ -339,7 +339,7 @@ func (c *Client) GetStockExchanges() ([]StockExchange, error) {
 	}
 
 	q := u.Query()
-	q.Set("apiKey", c.credentials.ID)
+	q.Set("apiKey", c.credentials.PolygonKeyID)
 
 	u.RawQuery = q.Encode()
 

--- a/polygon/stream.go
+++ b/polygon/stream.go
@@ -196,7 +196,7 @@ func (s *Stream) auth() (err error) {
 
 	authRequest := PolygonClientMsg{
 		Action: "auth",
-		Params: common.Credentials().ID,
+		Params: common.Credentials().PolygonKeyID,
 	}
 
 	if err = s.conn.WriteJSON(authRequest); err != nil {


### PR DESCRIPTION
A paper Alpaca API key no longer works for Polygon. From Quintin Pike, in Slack's #dev-polygon:

> We have upgraded WebSockets to the latest version which has proven much more stable. In doing that the auth service has been rewritten. Apparently, before you could use paper trading credentials. However, that was unintentional and fixed in the new service.

This poses a bit of a problem. I want to consume Polygon data, but I want to keep using my paper account.

The only solution I can think around this is to have the Polygon API key be a separate env var. This can be a prod Alpaca key, while the Alpaca client can continue to use the paper API keys.

/cc @ttt733 @umitanuki 