### PR TITLE
Change trade id to be string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/alpacahq/alpaca-trade-api-go
 
+go 1.14
+
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/polygon/entities.go
+++ b/polygon/entities.go
@@ -228,7 +228,7 @@ type PolgyonServerMsg struct {
 type StreamTrade struct {
 	Symbol     string  `json:"sym"`
 	Exchange   int     `json:"x"`
-	TradeID    int64   `json:"i"`
+	TradeID    string  `json:"i"`
 	Price      float64 `json:"p"`
 	Size       int64   `json:"s"`
 	Timestamp  int64   `json:"t"`


### PR DESCRIPTION
Addresses issue #66 

Currently when using the sdk i see errors like
`2020/04/16 19:55:07 polygon stream read error (json: cannot unmarshal string into Go struct field StreamTrade.i of type int64)`

This can be solved by changing the type to string.