### PR TITLE
Enables account specific stream (backwards-compatible)

### DIFF
--- a/alpaca/stream.go
+++ b/alpaca/stream.go
@@ -218,8 +218,8 @@ func (s *Stream) auth() (err error) {
 	authRequest := ClientMsg{
 		Action: "authenticate",
 		Data: map[string]interface{}{
-			"key_id":     common.Credentials().ID,
-			"secret_key": common.Credentials().Secret,
+			"key_id":     s.credentials.ID,
+			"secret_key": s.credentials.Secret,
 		},
 	}
 


### PR DESCRIPTION
A common use case is to use a stream for each alpaca account. Often traders may have multiple accounts for different environments or portfolios. A trader should be able to specify which account a stream is pulling from and run multiple streams in the same program.