### PR TITLE
Feature - Get Order by client_order_id

### DIFF
--- a/alpaca/alpaca_test.go
+++ b/alpaca/alpaca_test.go
@@ -428,6 +428,32 @@ func (s *AlpacaTestSuite) TestAlpaca() {
 		assert.Nil(s.T(), order)
 	}
 
+	// get order by client_order_id
+	{
+		// successful
+		do = func(c *Client, req *http.Request) (*http.Response, error) {
+			order := Order{
+				ClientOrderID: "some_client_order_id",
+			}
+			return &http.Response{
+				Body: genBody(order),
+			}, nil
+		}
+
+		order, err := GetOrderByClientOrderID("some_client_order_id")
+		assert.Nil(s.T(), err)
+		assert.NotNil(s.T(), order)
+
+		// api failure
+		do = func(c *Client, req *http.Request) (*http.Response, error) {
+			return &http.Response{}, fmt.Errorf("fail")
+		}
+
+		order, err = GetOrderByClientOrderID("some_client_order_id")
+		assert.NotNil(s.T(), err)
+		assert.Nil(s.T(), order)
+	}
+
 	// cancel order
 	{
 		// successful

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -539,6 +539,27 @@ func (c *Client) GetOrder(orderID string) (*Order, error) {
 	return order, nil
 }
 
+// GetOrderByClientOrderID submits a request to get an order by the client order ID.
+func (c *Client) GetOrderByClientOrderID(clientOrderID string) (*Order, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/%s/orders:%s", base, apiVersion, clientOrderID))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.get(u)
+	if err != nil {
+		return nil, err
+	}
+
+	order := &Order{}
+
+	if err = unmarshal(resp, order); err != nil {
+		return nil, err
+	}
+
+	return order, nil
+}
+
 // ReplaceOrder submits a request to replace an order by id
 func (c *Client) ReplaceOrder(orderID string, req ReplaceOrderRequest) (*Order, error) {
 	u, err := url.Parse(fmt.Sprintf("%s/%s/orders/%s", base, apiVersion, orderID))
@@ -777,6 +798,12 @@ func PlaceOrder(req PlaceOrderRequest) (*Order, error) {
 // `orderID` using the default Alpaca client.
 func GetOrder(orderID string) (*Order, error) {
 	return DefaultClient.GetOrder(orderID)
+}
+
+// GetOrderByClientOrderID returns a single order for the given
+// `clientOrderID` using the default Alpaca client.
+func GetOrderByClientOrderID(clientOrderID string) (*Order, error) {
+	return DefaultClient.GetOrderByClientOrderID(clientOrderID)
 }
 
 // ReplaceOrder changes an order by order id


### PR DESCRIPTION
Adding GET endpoint for Order using client_order_id [API Reference](https://alpaca.markets/docs/api-documentation/api-v2/orders/#get-an-order-by-client-order-id)

Fixes #32 