### PR TITLE
Extra Polygon Functions

### DIFF
--- a/polygon/entities.go
+++ b/polygon/entities.go
@@ -276,3 +276,50 @@ type StockExchange struct {
 	Name   string `json:"name"`
 	Tape   string `json:"tape"`
 }
+
+// Tick is the structure that defines single day's Open, High, Low, Close
+// and Volume
+type Tick struct {
+	Close  float64 `json:"c"`
+	High   float64 `json:"h"`
+	Low    float64 `json:"l"`
+	Open   float64 `json:"o"`
+	Volume float64 `json:"v"`
+}
+
+// Ticker is the structure that defines a single day's Ticker information
+// in Tickers
+type Ticker struct {
+	Ticker    string `json:"ticker"`
+	Day       Tick   `json:"day"`
+	LastTrade struct {
+		Cond1     int     `json:"c1"`
+		Cond2     int     `json:"c2"`
+		Cond3     int     `json:"c3"`
+		Cond4     int     `json:"c4"`
+		Exchange  int     `json:"e"`
+		Price     float64 `json:"p"`
+		Size      int     `json:"s"`
+		Timestamp int64   `json:"t"`
+	} `json:"lastTrade"`
+	LastQuote struct {
+		AskPrice  float64 `json:"p"`
+		AskSize   int     `json:"s"`
+		BidPrice  float64 `json:"P"`
+		BidSize   int     `json:"S"`
+		Timestamp int64   `json:"t"`
+	} `json:"lastQuote"`
+	Min              Tick    `json:"min"`
+	PrevDay          Tick    `json:"prevDay"`
+	TodaysChange     float64 `json:"todaysChange"`
+	TodaysChangePerc float64 `json:"todaysChangePerc"`
+	Updated          int64   `json:"updated"`
+}
+
+// Tickers is the structure that defines the Tickers aggregate that
+// polygon transmits via:
+// https://polygon.io/docs/#get_v2_snapshot_locale_us_markets_stocks_tickers_anchor
+type Tickers struct {
+	Status  string   `json:"status"`
+	Tickers []Ticker `json:"tickers"`
+}

--- a/polygon/polygon_test.go
+++ b/polygon/polygon_test.go
@@ -120,6 +120,76 @@ func (s *PolygonTestSuite) TestPolygon() {
 		assert.NotNil(s.T(), err)
 		assert.Nil(s.T(), resp)
 	}
+
+	// get all tickers
+	{
+		// successful
+		get = func(u *url.URL) (*http.Response, error) {
+			return &http.Response{
+				Body: genBody([]byte(allTickersBody)),
+			}, nil
+		}
+
+		resp, err := GetAllTickers()
+		assert.Nil(s.T(), err)
+		assert.NotNil(s.T(), resp)
+
+		// api failure
+		get = func(u *url.URL) (*http.Response, error) {
+			return &http.Response{}, fmt.Errorf("fail")
+		}
+
+		resp, err = GetAllTickers()
+		assert.NotNil(s.T(), err)
+		assert.Nil(s.T(), resp)
+	}
+
+	// get top 20 gainers
+	{
+		// successful
+		get = func(u *url.URL) (*http.Response, error) {
+			return &http.Response{
+				Body: genBody([]byte(top20GainersLosersBody)),
+			}, nil
+		}
+
+		resp, err := GetTop20Gainers()
+		assert.Nil(s.T(), err)
+		assert.NotNil(s.T(), resp)
+
+		// api failure
+		get = func(u *url.URL) (*http.Response, error) {
+			return &http.Response{}, fmt.Errorf("fail")
+		}
+
+		resp, err = GetTop20Gainers()
+		assert.NotNil(s.T(), err)
+		assert.Nil(s.T(), resp)
+	}
+
+	// get top 20 losers
+	{
+		// successful
+		get = func(u *url.URL) (*http.Response, error) {
+			return &http.Response{
+				Body: genBody([]byte(top20GainersLosersBody)),
+			}, nil
+		}
+
+		resp, err := GetTop20Losers()
+		assert.Nil(s.T(), err)
+		assert.NotNil(s.T(), resp)
+
+		// api failure
+		get = func(u *url.URL) (*http.Response, error) {
+			return &http.Response{}, fmt.Errorf("fail")
+		}
+
+		resp, err = GetTop20Losers()
+		assert.NotNil(s.T(), err)
+		assert.Nil(s.T(), resp)
+	}
+
 }
 
 type nopCloser struct {
@@ -247,4 +317,102 @@ const (
 		  "tape": "W"
 		}
 	  ]`
+	allTickersBody = `{
+		  "status": "OK",
+		  "tickers": [
+			{
+			  "ticker": "AAPL",
+			  "day": {
+				"c": 0.2907,
+				"h": 0.2947,
+				"l": 0.2901,
+				"o": 0.2905,
+				"v": 1432
+			  },
+			  "lastTrade": {
+				"c1": 14,
+				"c2": 12,
+				"c3": 0,
+				"c4": 0,
+				"e": 12,
+				"p": 172.17,
+				"s": 50,
+				"t": 1517529601006
+			  },
+			  "lastQuote": {
+				"p": 120,
+				"s": 5,
+				"P": 121,
+				"S": 3,
+				"t": 1547787608999000000
+			  },
+			  "min": {
+				"c": 0.2907,
+				"h": 0.2947,
+				"l": 0.2901,
+				"o": 0.2905,
+				"v": 1432
+			  },
+			  "prevDay": {
+				"c": 0.2907,
+				"h": 0.2947,
+				"l": 0.2901,
+				"o": 0.2905,
+				"v": 1432
+			  },
+			  "todaysChange": 0.001,
+			  "todaysChangePerc": 2.55,
+			  "updated": 1547787608999
+			}
+		  ]
+		}`
+	top20GainersLosersBody = `{
+		  "status": "OK",
+		  "tickers": [
+			{
+			  "ticker": "AAPL",
+			  "day": {
+				"c": 0.2907,
+				"h": 0.2947,
+				"l": 0.2901,
+				"o": 0.2905,
+				"v": 1432
+			  },
+			  "lastTrade": {
+				"c1": 14,
+				"c2": 12,
+				"c3": 0,
+				"c4": 0,
+				"e": 12,
+				"p": 172.17,
+				"s": 50,
+				"t": 1517529601006
+			  },
+			  "lastQuote": {
+				"p": 120,
+				"s": 5,
+				"P": 121,
+				"S": 3,
+				"t": 1547787608999000000
+			  },
+			  "min": {
+				"c": 0.2907,
+				"h": 0.2947,
+				"l": 0.2901,
+				"o": 0.2905,
+				"v": 1432
+			  },
+			  "prevDay": {
+				"c": 0.2907,
+				"h": 0.2947,
+				"l": 0.2901,
+				"o": 0.2905,
+				"v": 1432
+			  },
+			  "todaysChange": 0.001,
+			  "todaysChangePerc": 2.55,
+			  "updated": 1547787608999
+			}
+		  ]
+		}`
 )


### PR DESCRIPTION
This commit adds extra functions provided by the Polygon REST API that I find useful:
- GetAllTickers: Based on [this](https://polygon.io/docs/#get_v2_snapshot_locale_us_markets_stocks_tickers_anchor) API call.
  - Snapshot allows you to see all tickers current minute aggregate, daily aggregate and last trade. As well as previous days aggregate and calculated change for today.
- GetTop20Gainers and GetTop20Losers: Based on [this](https://polygon.io/docs/#get_v2_snapshot_locale_us_markets_stocks__direction__anchor) API call.
  - See the current snapshot of the top 20 gainers or losers of the day at the moment.