### PR TITLE
Add streamUrl to allow proxying streaming connection

### DIFF
--- a/alpaca/stream.go
+++ b/alpaca/stream.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -264,11 +265,17 @@ func GetStream() *Stream {
 }
 
 func GetDataStream() *Stream {
+	var streamUrl string
+	if s := os.Getenv("DATA_PROXY_WS"); s != "" {
+		streamUrl = s
+	} else {
+		streamUrl = dataUrl
+	}
 	dataOnce.Do(func() {
 		dataStr = &Stream{
 			authenticated: atomic.Value{},
 			handlers:      sync.Map{},
-			base:          dataUrl,
+			base:          streamUrl,
 		}
 
 		dataStr.authenticated.Store(false)


### PR DESCRIPTION
The PR adds the ability for users to have a separate `dataURL` for REST based market data queries and use a `streamURL` for stream based market data. Separating them allows for easier proxying. The current implementation also allows for backwards compatibility and if someone only sets the `dataURL` it will also set the `streamUrl`