### PR TITLE
feat(unsubscribe): added unsubscribe functionality to stream

### DIFF
--- a/alpaca/stream.go
+++ b/alpaca/stream.go
@@ -2,6 +2,7 @@ package alpaca
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -78,6 +79,24 @@ func (s *Stream) Subscribe(channel string, handler func(msg interface{})) (err e
 		s.handlers.Delete(channel)
 		return
 	}
+	return
+}
+
+// Unsubscribe the specified Polygon stream channel.
+func (s *Stream) Unsubscribe(channel string) (err error) {
+	if s.conn == nil {
+		err = errors.New("not yet subscribed to any channel")
+		return
+	}
+
+	if err = s.auth(); err != nil {
+		return
+	}
+
+	s.handlers.Delete(channel)
+
+	err = s.unsub(channel)
+
 	return
 }
 
@@ -190,6 +209,26 @@ func (s *Stream) sub(channel string) (err error) {
 
 	subReq := ClientMsg{
 		Action: "listen",
+		Data: map[string]interface{}{
+			"streams": []interface{}{
+				channel,
+			},
+		},
+	}
+
+	if err = s.conn.WriteJSON(subReq); err != nil {
+		return
+	}
+
+	return
+}
+
+func (s *Stream) unsub(channel string) (err error) {
+	s.Lock()
+	defer s.Unlock()
+
+	subReq := ClientMsg{
+		Action: "unlisten",
 		Data: map[string]interface{}{
 			"streams": []interface{}{
 				channel,

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -36,11 +36,15 @@ func (s *StreamTestSuite) TestStream() {
 	assert.Nil(s.T(), Register(alpaca.AccountUpdates, h))
 	assert.Nil(s.T(), Register("T.*", h))
 	assert.Nil(s.T(), Close())
+	assert.Nil(s.T(), Deregister(alpaca.TradeUpdates))
+	assert.Nil(s.T(), Deregister(alpaca.AccountUpdates))
+	assert.Nil(s.T(), Deregister("T.*"))
 
 	// failure
 	s.alp.fail = true
 	assert.NotNil(s.T(), Register(alpaca.TradeUpdates, h))
 	assert.NotNil(s.T(), Close())
+	assert.NotNil(s.T(), Deregister(alpaca.TradeUpdates))
 }
 
 type MockStream struct {
@@ -50,6 +54,14 @@ type MockStream struct {
 func (ms *MockStream) Subscribe(key string, handler func(msg interface{})) error {
 	if ms.fail {
 		return fmt.Errorf("failed to subscribe")
+	}
+
+	return nil
+}
+
+func (ms *MockStream) Unsubscribe(key string) error {
+	if ms.fail {
+		return fmt.Errorf("failed to unsubscribe")
 	}
 
 	return nil


### PR DESCRIPTION
With this PR I added the functionality to unsubscribe specific streaming channels.

Example:
```
// Subscribe to channel
err = stream.Register("T.*", handler)

// Unsubscribe channel
err = stream.Deregister("T.*")
```

This functionality is already possible in the python version of this package.