### PR TITLE
updating volume entity to return int64 for volume.

### DIFF
--- a/alpaca/alpaca_test.go
+++ b/alpaca/alpaca_test.go
@@ -535,7 +535,7 @@ func (s *AlpacaTestSuite) TestAlpaca() {
 					High:   80.86,
 					Low:    80.02,
 					Close:  80.51,
-					Volume: 4283085,
+					Volume: 2147483655,
 				},
 			}
 			var barsMap = make(map[string][]Bar)
@@ -549,6 +549,7 @@ func (s *AlpacaTestSuite) TestAlpaca() {
 		assert.Nil(s.T(), err)
 		require.Len(s.T(), bars, 1)
 		assert.Equal(s.T(), int64(1551157200), bars["APCA"][0].Time)
+		assert.Equal(s.T(), int64(2147483655), bars["APCA"][0].Volume)
 
 		// api failure
 		do = func(c *Client, req *http.Request) (*http.Response, error) {

--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -132,7 +132,7 @@ type Bar struct {
 	High   float32 `json:"h"`
 	Low    float32 `json:"l"`
 	Close  float32 `json:"c"`
-	Volume int32   `json:"v"`
+	Volume int64   `json:"v"`
 }
 
 type ListBarParams struct {


### PR DESCRIPTION
Related to [issue](https://github.com/alpacahq/alpaca-trade-api-go/issues/112). Updated tests. 