### PR TITLE
Fix mean-reversion example

### DIFF
--- a/examples/mean-reversion/mean-reversion.go
+++ b/examples/mean-reversion/mean-reversion.go
@@ -190,7 +190,7 @@ func (alp alpacaClientContainer) rebalance() {
 			if qtyToSell > positionQty {
 				qtyToSell = positionQty
 			}
-			alp.submitLimitOrder(qtyToSell, alpacaClient.stock, currPrice, "buy")
+			alp.submitLimitOrder(qtyToSell, alpacaClient.stock, currPrice, "sell")
 		}
 	}
 }


### PR DESCRIPTION
Fixes a small bug in the mean-reversion example where we mean to sell our shares instead of buy them.