### PR TITLE
Add timestamp, position_qty, qty, price to TradeUpdate websocket struct

### DIFF
--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -419,6 +419,7 @@ type ServerMsg struct {
 
 type TradeUpdate struct {
 	Event       string           `json:"event"`
+	ExecutionID string           `json:"execution_id"`
 	Order       Order            `json:"order"`
 	PositionQty *decimal.Decimal `json:"position_qty"`
 	Price       *decimal.Decimal `json:"price"`

--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -418,8 +418,12 @@ type ServerMsg struct {
 }
 
 type TradeUpdate struct {
-	Event string `json:"event"`
-	Order Order  `json:"order"`
+	Event       string           `json:"event"`
+	Order       Order            `json:"order"`
+	PositionQty *decimal.Decimal `json:"position_qty"`
+	Price       *decimal.Decimal `json:"price"`
+	Qty         *decimal.Decimal `json:"qty"`
+	Timestamp   *time.Time       `json:"timestamp"`
 }
 
 type StreamAgg struct {


### PR DESCRIPTION
When trade updates are sent over the websocket, they sometimes (depending on the event) include `position_qty`, `price`, `qty`, `timestamp`, and `execution_id`. These are particularly useful for `partial_fill` updates where you need to know how many shares were filled as part of the partial fill.

Pulled from the docs here:
https://alpaca.markets/docs/api-documentation/api-v2/streaming/

Here's a sample `fill` event that contains these items:

```json
{
  "stream": "trade_updates",
  "data": {
    "event": "fill",
    "execution_id": "adb4f7c7-45fe-4a3a-a0ac-02d9fa3c8264",
    "order": {
      "asset_class": "us_equity",
      "asset_id": "3e59f0bd-a197-4e69-995a-733be53ecb0f",
      "canceled_at": null,
      "client_order_id": "2bc205b7-57d4-4aee-8cd4-129f51b152fd",
      "created_at": "2021-07-29T15:28:16.830808Z",
      "expired_at": null,
      "extended_hours": false,
      "failed_at": null,
      "filled_at": "2021-07-29T15:28:16.88853Z",
      "filled_avg_price": "7.09",
      "filled_qty": "1",
      "hwm": null,
      "id": "417b6eea-5cc2-4e30-9ee4-68e91ceee8ed",
      "legs": null,
      "limit_price": "7.09",
      "notional": null,
      "order_class": "",
      "order_type": "limit",
      "qty": "1",
      "replaced_at": null,
      "replaced_by": null,
      "replaces": null,
      "side": "buy",
      "status": "filled",
      "stop_price": null,
      "submitted_at": "2021-07-29T15:28:16.822868Z",
      "symbol": "OCGN",
      "time_in_force": "day",
      "trail_percent": null,
      "trail_price": null,
      "type": "limit",
      "updated_at": "2021-07-29T15:28:16.919438Z"
    },
    "position_qty": "1",
    "price": "7.09",
    "qty": "1",
    "timestamp": "2021-07-29T15:28:16.888530891Z"
  }
}
```