### PR TITLE
Make price properties of Position entity nullable

### DIFF
--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -72,21 +72,21 @@ type Order struct {
 }
 
 type Position struct {
-	AssetID        string          `json:"asset_id"`
-	Symbol         string          `json:"symbol"`
-	Exchange       string          `json:"exchange"`
-	Class          string          `json:"asset_class"`
-	AccountID      string          `json:"account_id"`
-	EntryPrice     decimal.Decimal `json:"avg_entry_price"`
-	Qty            decimal.Decimal `json:"qty"`
-	Side           string          `json:"side"`
-	MarketValue    decimal.Decimal `json:"market_value"`
-	CostBasis      decimal.Decimal `json:"cost_basis"`
-	UnrealizedPL   decimal.Decimal `json:"unrealized_pl"`
-	UnrealizedPLPC decimal.Decimal `json:"unrealized_plpc"`
-	CurrentPrice   decimal.Decimal `json:"current_price"`
-	LastdayPrice   decimal.Decimal `json:"lastday_price"`
-	ChangeToday    decimal.Decimal `json:"change_today"`
+	AssetID        string           `json:"asset_id"`
+	Symbol         string           `json:"symbol"`
+	Exchange       string           `json:"exchange"`
+	Class          string           `json:"asset_class"`
+	AccountID      string           `json:"account_id"`
+	EntryPrice     decimal.Decimal  `json:"avg_entry_price"`
+	Qty            decimal.Decimal  `json:"qty"`
+	Side           string           `json:"side"`
+	MarketValue    *decimal.Decimal `json:"market_value"`
+	CostBasis      decimal.Decimal  `json:"cost_basis"`
+	UnrealizedPL   *decimal.Decimal `json:"unrealized_pl"`
+	UnrealizedPLPC *decimal.Decimal `json:"unrealized_plpc"`
+	CurrentPrice   *decimal.Decimal `json:"current_price"`
+	LastdayPrice   *decimal.Decimal `json:"lastday_price"`
+	ChangeToday    *decimal.Decimal `json:"change_today"`
 }
 
 type Asset struct {


### PR DESCRIPTION
**This is a breaking change**

There are cases when an account may have a position in an asset that does not have a current price. This can occur when certain corporate actions are processed or when a stock gets delisted.

In this scenario, API endpoints that call functions that use asset prices are returning an error response.

In order to avoid the error response and keep the API available even in the event that one of your positions’ underlying asset is missing a price, we will introduce a minor breaking change to the API.

Starting September 9, 2021, the following API response fields will change from non-nullable to nullable. They will appear null in the response in the case that the underlying asset is missing the price for some reason.

This change updates this SDK to be in-line with these upcoming API changes. **We will be releasing this as a major version that we recommend all user's update to ASAP.**
