### PR TITLE
Consider all HTTP 4xx irrecoverable errors

### DIFF
--- a/examples/crypto-stream/crypto_stream.go
+++ b/examples/crypto-stream/crypto_stream.go
@@ -12,7 +12,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Creating a client that connexts to iex
+	// Creating a client that connects to iex
 	c := stream.NewCryptoClient(
 		stream.WithLogger(&logger{}),
 		// configuring initial subscriptions and handlers
@@ -22,7 +22,7 @@ func main() {
 		stream.WithCryptoQuotes(func(cq stream.CryptoQuote) {
 			fmt.Printf("QUOTE: %+v\n", cq)
 		}, "BTCUSD"),
-		// stream.WithExchanges("EXAMPLE"),
+		// stream.WithExchanges("CBSE"),
 	)
 	if err := c.Connect(ctx); err != nil {
 		panic(err)


### PR DESCRIPTION
Currently if on the marketdata stream we receive an HTTP 422 from the server, the client will try to reconnect. This makes no sense, because the response will always be the same.