### PR TITLE
Dail has been marked as deprecated 

### DIFF
--- a/alpaca/stream.go
+++ b/alpaca/stream.go
@@ -18,7 +18,7 @@ import (
 // function for each trade update until the context is cancelled.
 func (c *client) StreamTradeUpdates(ctx context.Context, handler func(TradeUpdate)) error {
 	transport := http.Transport{
-		Dial: func(network, addr string) (net.Conn, error) {
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return net.DialTimeout(network, addr, 5*time.Second)
 		},
 	}


### PR DESCRIPTION
Inside the `StreamTradeUpdates` method, the HTTP Transport was using the now marked as deprecated Dail field. Instead lets use `DailContext` and allow the value to be:

```go
 func(ctx context.Context, network, addr string) (net.Conn, error) {
			return net.DialTimeout(network, addr, 5*time.Second)
		}
```