### PR TITLE
Improve marketdata stream error handling for a few cases

### DIFF
--- a/marketdata/stream/client.go
+++ b/marketdata/stream/client.go
@@ -246,9 +246,6 @@ func (cc *cryptoClient) constructURL() (url.URL, error) {
 	return url.URL{Scheme: scheme, Host: ub.Host, Path: ub.Path, RawQuery: rawQuery}, nil
 }
 
-// ErrConnectCalledMultipleTimes is returned when Connect has been called multiple times on a single client
-var ErrConnectCalledMultipleTimes = errors.New("tried to call Connect multiple times")
-
 func (c *client) connect(ctx context.Context, u url.URL) error {
 	err := ErrConnectCalledMultipleTimes
 	c.connectOnce.Do(func() {

--- a/marketdata/stream/client.go
+++ b/marketdata/stream/client.go
@@ -381,7 +381,8 @@ func (c *client) maintainConnection(ctx context.Context, u url.URL, initialResul
 // isErrorIrrecoverable returns whether the error is irrecoverable and further retries should
 // not take place
 func isErrorIrrecoverable(err error) bool {
-	return errors.Is(err, ErrInvalidCredentials) || errors.Is(err, ErrInsufficientSubscription)
+	return errors.Is(err, ErrInvalidCredentials) || errors.Is(err, ErrInsufficientSubscription) ||
+		errors.Is(err, ErrInsufficientScope)
 }
 
 func isHttp4xx(err error) bool {

--- a/marketdata/stream/client_test.go
+++ b/marketdata/stream/client_test.go
@@ -94,6 +94,7 @@ func TestConnectImmediatelyFailsAfterIrrecoverableErrors(t *testing.T) {
 	}{
 		{code: 402, msg: "auth failed", err: ErrInvalidCredentials},
 		{code: 409, msg: "insufficient subscription", err: ErrInsufficientSubscription},
+		{code: 411, msg: "insufficient scope", err: ErrInsufficientScope},
 	}
 	for _, tt := range tests {
 		for _, ie := range irrecoverableErrors {

--- a/marketdata/stream/client_test.go
+++ b/marketdata/stream/client_test.go
@@ -574,6 +574,27 @@ func TestSubscribeFailsDueToError(t *testing.T) {
 	err = <-subRes
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrSlowClient))
+
+	// attempting another sub change
+	go subFunc()
+	// wait for message to be written
+	subMsg = expectWrite(t, connection)
+	require.Equal(t, "subscribe", subMsg["action"])
+	require.ElementsMatch(t, []string{"PACOIN"}, subMsg["trades"])
+
+	// sub change request fails due to incorrect due to incorrect subscription for feed
+	connection.readCh <- serializeToMsgpack(t, []errorWithT{
+		{
+			Type: "error",
+			Code: 410,
+			Msg:  "invalid subscribe action for this feed",
+		},
+	})
+
+	// making sure the subscription request has failed
+	err = <-subRes
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrSubscriptionChangeInvalidForFeed))
 }
 
 func TestPingFails(t *testing.T) {

--- a/marketdata/stream/entities.go
+++ b/marketdata/stream/entities.go
@@ -102,3 +102,16 @@ type errorMessage struct {
 	msg  string
 	code int
 }
+
+func (e errorMessage) Error() string {
+	// NOTE: these special cases exist because the error message
+	// used to be different from the one sent by the server
+	switch e.code {
+	case 402:
+		return "invalid credentials"
+	case 410:
+		return "subscription change invalid for feed"
+	}
+
+	return e.msg
+}

--- a/marketdata/stream/errors.go
+++ b/marketdata/stream/errors.go
@@ -8,7 +8,7 @@ var (
 	// ErrNoConnected is returned when the client did not receive the welcome
 	// message from the server
 	ErrNoConnected = errors.New("did not receive connected message")
-	//ErrBadAuthResponse is returned when the client could not successfully authenticate
+	// ErrBadAuthResponse is returned when the client could not successfully authenticate
 	ErrBadAuthResponse = errors.New("did not receive authenticated message")
 	// ErrSubResponse is returned when the client's subscription request was not
 	// acknowledged

--- a/marketdata/stream/errors.go
+++ b/marketdata/stream/errors.go
@@ -2,62 +2,52 @@ package stream
 
 import "errors"
 
-// ErrConnectCalledMultipleTimes is returned when Connect has been called multiple times on a single client
-var ErrConnectCalledMultipleTimes = errors.New("tried to call Connect multiple times")
-
-// ErrNoConnected is returned when the client did not receive the welcome
-// message from the server
-var ErrNoConnected = errors.New("did not receive connected message")
-
-//ErrBadAuthResponse is returned when the client could not successfully authenticate
-var ErrBadAuthResponse = errors.New("did not receive authenticated message")
-
-// ErrSubResponse is returned when the client's subscription request was not
-// acknowledged
-var ErrSubResponse = errors.New("did not receive subscribed message")
-
-// ErrSubscriptionChangeBeforeConnect is returned when the client attempts to change subscriptions before
-// calling Connect
-var ErrSubscriptionChangeBeforeConnect = errors.New("subscription change attempted before calling Connect")
-
-// ErrSubscriptionChangeAfterTerminated is returned when client attempts to change subscriptions after
-// the client has been terminated
-var ErrSubscriptionChangeAfterTerminated = errors.New("subscription change after client termination")
-
-// ErrSubscriptionChangeAlreadyInProgress is returned when a subscription change is called concurrently
-// with another
-var ErrSubscriptionChangeAlreadyInProgress = errors.New("subscription change already in progress")
-
-// ErrSubscriptionChangeInterrupted is returned when a subscription change was in progress when the client
-// has terminated
-var ErrSubscriptionChangeInterrupted = errors.New("subscription change interrupted by client termination")
-
-// ErrSubscriptionChangeTimeout is returned when the server does not return a proper
-// subscription response after a subscription change request.
-var ErrSubscriptionChangeTimeout = errors.New("subscription change timeout")
+var (
+	// ErrConnectCalledMultipleTimes is returned when Connect has been called multiple times on a single client
+	ErrConnectCalledMultipleTimes = errors.New("tried to call Connect multiple times")
+	// ErrNoConnected is returned when the client did not receive the welcome
+	// message from the server
+	ErrNoConnected = errors.New("did not receive connected message")
+	//ErrBadAuthResponse is returned when the client could not successfully authenticate
+	ErrBadAuthResponse = errors.New("did not receive authenticated message")
+	// ErrSubResponse is returned when the client's subscription request was not
+	// acknowledged
+	ErrSubResponse = errors.New("did not receive subscribed message")
+	// ErrSubscriptionChangeBeforeConnect is returned when the client attempts to change subscriptions before
+	// calling Connect
+	ErrSubscriptionChangeBeforeConnect = errors.New("subscription change attempted before calling Connect")
+	// ErrSubscriptionChangeAfterTerminated is returned when client attempts to change subscriptions after
+	// the client has been terminated
+	ErrSubscriptionChangeAfterTerminated = errors.New("subscription change after client termination")
+	// ErrSubscriptionChangeAlreadyInProgress is returned when a subscription change is called concurrently
+	// with another
+	ErrSubscriptionChangeAlreadyInProgress = errors.New("subscription change already in progress")
+	// ErrSubscriptionChangeInterrupted is returned when a subscription change was in progress when the client
+	// has terminated
+	ErrSubscriptionChangeInterrupted = errors.New("subscription change interrupted by client termination")
+	// ErrSubscriptionChangeTimeout is returned when the server does not return a proper
+	// subscription response after a subscription change request.
+	ErrSubscriptionChangeTimeout = errors.New("subscription change timeout")
+)
 
 // The following errors are returned when the client receives an error message from the server
 
-// ErrInvalidCredentials is returned when invalid credentials have been sent by the user.
-var ErrInvalidCredentials error = errorMessage{msg: "auth failed", code: 402}
-
-// ErrSymbolLimitExceeded is returned when the client has subscribed to too many symbols
-var ErrSymbolLimitExceeded error = errorMessage{msg: "symbol limit exceeded", code: 405}
-
-// ErrConnectionLimitExceeded is returned when the client has exceeded their connection limit
-var ErrConnectionLimitExceeded error = errorMessage{msg: "connection limit exceeded", code: 406}
-
-// ErrSlowClient is returned when the server has detected a slow client. In this case there's no guarantee
-// that all prior messages are sent to the server so a subscription acknowledgement may not arrive
-var ErrSlowClient error = errorMessage{msg: "slow client", code: 407}
-
-// ErrInsufficientSubscription is returned when the user does not have proper
-// subscription for the requested feed (e.g. SIP)
-var ErrInsufficientSubscription error = errorMessage{msg: "insufficient subscription", code: 409}
-
-// ErrSubscriptionChangeTimeout is returned when a subscription change is invalid for the feed.
-var ErrSubscriptionChangeInvalidForFeed error = errorMessage{msg: "invalid subscribe action for this feed", code: 410}
-
-// ErrInsufficientScope is returned when the token used by the user doesn't have proper scopes
-// for data stream
-var ErrInsufficientScope error = errorMessage{msg: "insufficient scope", code: 411}
+var (
+	// ErrInvalidCredentials is returned when invalid credentials have been sent by the user.
+	ErrInvalidCredentials error = errorMessage{msg: "auth failed", code: 402}
+	// ErrSymbolLimitExceeded is returned when the client has subscribed to too many symbols
+	ErrSymbolLimitExceeded error = errorMessage{msg: "symbol limit exceeded", code: 405}
+	// ErrConnectionLimitExceeded is returned when the client has exceeded their connection limit
+	ErrConnectionLimitExceeded error = errorMessage{msg: "connection limit exceeded", code: 406}
+	// ErrSlowClient is returned when the server has detected a slow client. In this case there's no guarantee
+	// that all prior messages are sent to the server so a subscription acknowledgement may not arrive
+	ErrSlowClient error = errorMessage{msg: "slow client", code: 407}
+	// ErrInsufficientSubscription is returned when the user does not have proper
+	// subscription for the requested feed (e.g. SIP)
+	ErrInsufficientSubscription error = errorMessage{msg: "insufficient subscription", code: 409}
+	// ErrSubscriptionChangeInvalidForFeed is returned when a subscription change is invalid for the feed.
+	ErrSubscriptionChangeInvalidForFeed error = errorMessage{msg: "invalid subscribe action for this feed", code: 410}
+	// ErrInsufficientScope is returned when the token used by the user doesn't have proper scopes
+	// for data stream
+	ErrInsufficientScope error = errorMessage{msg: "insufficient scope", code: 411}
+)

--- a/marketdata/stream/errors.go
+++ b/marketdata/stream/errors.go
@@ -12,6 +12,10 @@ var ErrNoConnected = errors.New("did not receive connected message")
 //ErrBadAuthResponse is returned when the client could not successfully authenticate
 var ErrBadAuthResponse = errors.New("did not receive authenticated message")
 
+// ErrSubResponse is returned when the client's subscription request was not
+// acknowledged
+var ErrSubResponse = errors.New("did not receive subscribed message")
+
 // ErrSubscriptionChangeBeforeConnect is returned when the client attempts to change subscriptions before
 // calling Connect
 var ErrSubscriptionChangeBeforeConnect = errors.New("subscription change attempted before calling Connect")
@@ -32,30 +36,28 @@ var ErrSubscriptionChangeInterrupted = errors.New("subscription change interrupt
 // subscription response after a subscription change request.
 var ErrSubscriptionChangeTimeout = errors.New("subscription change timeout")
 
-// ErrConnectionLimitExceeded is returned when the client has exceeded their connection limit
-var ErrConnectionLimitExceeded error = errorMessage{msg: "connection limit exceeded", code: 406}
+// The following errors are returned when the client receives an error message from the server
 
 // ErrInvalidCredentials is returned when invalid credentials have been sent by the user.
 var ErrInvalidCredentials error = errorMessage{msg: "auth failed", code: 402}
 
-// ErrInsufficientSubscription is returned when the user does not have proper
-// subscription for the requested feed (e.g. SIP)
-var ErrInsufficientSubscription error = errorMessage{msg: "insufficient subscription", code: 409}
-
-// ErrInsufficientScope is returned when the token used by the user doesn't have proper scopes
-// for data stream
-var ErrInsufficientScope error = errorMessage{msg: "insufficient scope", code: 411}
-
 // ErrSymbolLimitExceeded is returned when the client has subscribed to too many symbols
 var ErrSymbolLimitExceeded error = errorMessage{msg: "symbol limit exceeded", code: 405}
+
+// ErrConnectionLimitExceeded is returned when the client has exceeded their connection limit
+var ErrConnectionLimitExceeded error = errorMessage{msg: "connection limit exceeded", code: 406}
 
 // ErrSlowClient is returned when the server has detected a slow client. In this case there's no guarantee
 // that all prior messages are sent to the server so a subscription acknowledgement may not arrive
 var ErrSlowClient error = errorMessage{msg: "slow client", code: 407}
 
+// ErrInsufficientSubscription is returned when the user does not have proper
+// subscription for the requested feed (e.g. SIP)
+var ErrInsufficientSubscription error = errorMessage{msg: "insufficient subscription", code: 409}
+
 // ErrSubscriptionChangeTimeout is returned when a subscription change is invalid for the feed.
 var ErrSubscriptionChangeInvalidForFeed error = errorMessage{msg: "invalid subscribe action for this feed", code: 410}
 
-// ErrSubResponse is returned when the client's subscription request was not
-// acknowledged
-var ErrSubResponse = errors.New("did not receive subscribed message")
+// ErrInsufficientScope is returned when the token used by the user doesn't have proper scopes
+// for data stream
+var ErrInsufficientScope error = errorMessage{msg: "insufficient scope", code: 411}

--- a/marketdata/stream/errors.go
+++ b/marketdata/stream/errors.go
@@ -1,0 +1,61 @@
+package stream
+
+import "errors"
+
+// ErrConnectCalledMultipleTimes is returned when Connect has been called multiple times on a single client
+var ErrConnectCalledMultipleTimes = errors.New("tried to call Connect multiple times")
+
+// ErrNoConnected is returned when the client did not receive the welcome
+// message from the server
+var ErrNoConnected = errors.New("did not receive connected message")
+
+//ErrBadAuthResponse is returned when the client could not successfully authenticate
+var ErrBadAuthResponse = errors.New("did not receive authenticated message")
+
+// ErrSubscriptionChangeBeforeConnect is returned when the client attempts to change subscriptions before
+// calling Connect
+var ErrSubscriptionChangeBeforeConnect = errors.New("subscription change attempted before calling Connect")
+
+// ErrSubscriptionChangeAfterTerminated is returned when client attempts to change subscriptions after
+// the client has been terminated
+var ErrSubscriptionChangeAfterTerminated = errors.New("subscription change after client termination")
+
+// ErrSubscriptionChangeAlreadyInProgress is returned when a subscription change is called concurrently
+// with another
+var ErrSubscriptionChangeAlreadyInProgress = errors.New("subscription change already in progress")
+
+// ErrSubscriptionChangeInterrupted is returned when a subscription change was in progress when the client
+// has terminated
+var ErrSubscriptionChangeInterrupted = errors.New("subscription change interrupted by client termination")
+
+// ErrSubscriptionChangeTimeout is returned when the server does not return a proper
+// subscription response after a subscription change request.
+var ErrSubscriptionChangeTimeout = errors.New("subscription change timeout")
+
+// ErrConnectionLimitExceeded is returned when the client has exceeded their connection limit
+var ErrConnectionLimitExceeded error = errorMessage{msg: "connection limit exceeded", code: 406}
+
+// ErrInvalidCredentials is returned when invalid credentials have been sent by the user.
+var ErrInvalidCredentials error = errorMessage{msg: "auth failed", code: 402}
+
+// ErrInsufficientSubscription is returned when the user does not have proper
+// subscription for the requested feed (e.g. SIP)
+var ErrInsufficientSubscription error = errorMessage{msg: "insufficient subscription", code: 409}
+
+// ErrInsufficientScope is returned when the token used by the user doesn't have proper scopes
+// for data stream
+var ErrInsufficientScope error = errorMessage{msg: "insufficient scope", code: 411}
+
+// ErrSymbolLimitExceeded is returned when the client has subscribed to too many symbols
+var ErrSymbolLimitExceeded error = errorMessage{msg: "symbol limit exceeded", code: 405}
+
+// ErrSlowClient is returned when the server has detected a slow client. In this case there's no guarantee
+// that all prior messages are sent to the server so a subscription acknowledgement may not arrive
+var ErrSlowClient error = errorMessage{msg: "slow client", code: 407}
+
+// ErrSubscriptionChangeTimeout is returned when a subscription change is invalid for the feed.
+var ErrSubscriptionChangeInvalidForFeed error = errorMessage{msg: "invalid subscribe action for this feed", code: 410}
+
+// ErrSubResponse is returned when the client's subscription request was not
+// acknowledged
+var ErrSubResponse = errors.New("did not receive subscribed message")

--- a/marketdata/stream/flow.go
+++ b/marketdata/stream/flow.go
@@ -132,6 +132,10 @@ var ErrInvalidCredentials = errors.New("invalid credentials")
 // subscription for the requested feed (e.g. SIP)
 var ErrInsufficientSubscription = errors.New("insufficient subscription")
 
+// ErrInsufficientScope is returned when the token used by the user doesn't have proper scopes
+// for data stream
+var ErrInsufficientScope = errors.New("insufficient scope")
+
 // isErrorRetriable returns whether the error is considered retriable during the initialization flow
 func isErrorRetriable(err error) bool {
 	return errors.Is(err, ErrConnectionLimitExceeded)
@@ -166,6 +170,8 @@ func (c *client) readAuthResponse(ctx context.Context) error {
 			return ErrConnectionLimitExceeded
 		case 409:
 			return ErrInsufficientSubscription
+		case 411:
+			return ErrInsufficientScope
 		}
 		return errors.New(resp.Msg)
 	}

--- a/marketdata/stream/flow.go
+++ b/marketdata/stream/flow.go
@@ -81,10 +81,6 @@ func (c *client) initialize(ctx context.Context) error {
 	return nil
 }
 
-// ErrNoConnected is returned when the client did not receive the welcome
-// message from the server
-var ErrNoConnected = errors.New("did not receive connected message")
-
 func (c *client) readConnected(ctx context.Context) error {
 	b, err := c.conn.readMessage(ctx)
 	if err != nil {
@@ -118,33 +114,6 @@ func (c *client) writeAuth(ctx context.Context) error {
 
 	return c.conn.writeMessage(ctx, msg)
 }
-
-//ErrBadAuthResponse is returned when the client could not successfully authenticate
-var ErrBadAuthResponse = errors.New("did not receive authenticated message")
-
-// ErrConnectionLimitExceeded is returned when the client has exceeded their connection limit
-var ErrConnectionLimitExceeded error = errorMessage{msg: "connection limit exceeded", code: 406}
-
-// ErrInvalidCredentials is returned when invalid credentials have been sent by the user.
-var ErrInvalidCredentials error = errorMessage{msg: "auth failed", code: 402}
-
-// ErrInsufficientSubscription is returned when the user does not have proper
-// subscription for the requested feed (e.g. SIP)
-var ErrInsufficientSubscription error = errorMessage{msg: "insufficient subscription", code: 409}
-
-// ErrInsufficientScope is returned when the token used by the user doesn't have proper scopes
-// for data stream
-var ErrInsufficientScope error = errorMessage{msg: "insufficient scope", code: 411}
-
-// ErrSymbolLimitExceeded is returned when the client has subscribed to too many symbols
-var ErrSymbolLimitExceeded error = errorMessage{msg: "symbol limit exceeded", code: 405}
-
-// ErrSlowClient is returned when the server has detected a slow client. In this case there's no guarantee
-// that all prior messages are sent to the server so a subscription acknowledgement may not arrive
-var ErrSlowClient error = errorMessage{msg: "slow client", code: 407}
-
-// ErrSubscriptionChangeTimeout is returned when a subscription change is invalid for the feed.
-var ErrSubscriptionChangeInvalidForFeed error = errorMessage{msg: "invalid subscribe action for this feed", code: 410}
 
 // isErrorRetriable returns whether the error is considered retriable during the initialization flow
 func isErrorRetriable(err error) bool {
@@ -191,10 +160,6 @@ func (c *client) writeSub(ctx context.Context) error {
 
 	return c.conn.writeMessage(ctx, msg)
 }
-
-// ErrSubResponse is returned when the client's subscription request was not
-// acknowledged
-var ErrSubResponse = errors.New("did not receive subscribed message")
 
 func (c *client) readSubResponse(ctx context.Context) error {
 	b, err := c.conn.readMessage(ctx)

--- a/marketdata/stream/flow_test.go
+++ b/marketdata/stream/flow_test.go
@@ -460,6 +460,7 @@ func TestReadAuthResponseContents(t *testing.T) {
 			message: serializeToMsgpack(t, []map[string]interface{}{
 				{
 					"T":    "error",
+					"msg":  "connection limit exceeded",
 					"code": 406,
 				},
 			}),

--- a/marketdata/stream/message.go
+++ b/marketdata/stream/message.go
@@ -478,11 +478,11 @@ var errMessageHandler = func(c *client, e errorMessage) error {
 		c.pendingSubChange = nil
 	}
 
+	c.logger.Warnf("datav2stream: got error from server: %+v", e)
 	if e.code == 0 || e.msg == "" {
 		return fmt.Errorf("datav2stream: received unexpected error: %s", e.msg)
 	}
 
-	c.logger.Warnf("datav2stream: got error from server: %s", e)
 	return nil
 }
 

--- a/marketdata/stream/message.go
+++ b/marketdata/stream/message.go
@@ -474,8 +474,8 @@ var errMessageHandler = func(c *client, e errorMessage) error {
 	c.pendingSubChangeMutex.Lock()
 	defer c.pendingSubChangeMutex.Unlock()
 	if c.pendingSubChange != nil {
-		c.pendingSubChange = nil
 		c.pendingSubChange.result <- e
+		c.pendingSubChange = nil
 	}
 
 	if e.code == 0 || e.msg == "" {

--- a/marketdata/stream/message.go
+++ b/marketdata/stream/message.go
@@ -478,17 +478,12 @@ var errMessageHandler = func(c *client, e errorMessage) error {
 		c.pendingSubChange = nil
 	}
 
-	if e.code != 0 && e.msg != "" {
-		c.logger.Warnf("datav2stream: got error from server: %s", e)
-		return nil
+	if e.code == 0 || e.msg == "" {
+		return fmt.Errorf("code: %d, msg: %s", e.code, e.msg)
 	}
-	if e.code == 0 && e.msg == "" {
-		return fmt.Errorf("datav2stream: received unexpected error: no code or msg")
-	}
-	if e.code == 0 {
-		return fmt.Errorf("datav2stream: received unexpected error: %s", e.msg)
-	}
-	return fmt.Errorf("datav2stream: received unexpected error: %d", e.code)
+
+	c.logger.Warnf("datav2stream: got error from server: %s", e)
+	return nil
 }
 
 func (c *client) handleErrorMessage(d *msgpack.Decoder, n int) error {

--- a/marketdata/stream/message.go
+++ b/marketdata/stream/message.go
@@ -2,7 +2,6 @@ package stream
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -471,35 +470,20 @@ func discardMapContents(d *msgpack.Decoder, n int) error {
 	return nil
 }
 
-//ErrSymbolLimitExceeded is returned when the client has subscribed to too many symbols
-var ErrSymbolLimitExceeded = errors.New("symbol limit exceeded")
-
-//ErrSlowClient is returned when the server has detected a slow client. In this case there's no guarantee
-// that all prior messages are sent to the server so a subscription acknowledgement may not arrive
-var ErrSlowClient = errors.New("slow client")
-
 var errMessageHandler = func(c *client, e errorMessage) error {
-	// {"T":"error","code":405,"msg":"symbol limit exceeded"}
-	// {"T":"error","code":407,"msg":"slow client"}
-	// {"T":"error","code":410,"msg":"invalid subscribe action for this feed"}
-	switch e.code {
-	case 405, 407, 410:
-		c.pendingSubChangeMutex.Lock()
-		defer c.pendingSubChangeMutex.Unlock()
-		if c.pendingSubChange != nil {
-			switch e.code {
-			case 405:
-				c.pendingSubChange.result <- ErrSymbolLimitExceeded
-			case 407:
-				c.pendingSubChange.result <- ErrSlowClient
-			case 410:
-				c.pendingSubChange.result <- ErrSubscriptionChangeInvalidForFeed
-			}
-			c.pendingSubChange = nil
-		}
+	c.pendingSubChangeMutex.Lock()
+	defer c.pendingSubChangeMutex.Unlock()
+	if c.pendingSubChange != nil {
+		c.pendingSubChange = nil
+		c.pendingSubChange.result <- e
 	}
 
-	return fmt.Errorf("datav2stream: received unexpected error: %s", e.msg)
+	if e.code == 0 || e.msg == "" {
+		return fmt.Errorf("datav2stream: received unexpected error: %s", e.msg)
+	}
+
+	c.logger.Warnf("datav2stream: got error from server: %s", e)
+	return nil
 }
 
 func (c *client) handleErrorMessage(d *msgpack.Decoder, n int) error {

--- a/marketdata/stream/message.go
+++ b/marketdata/stream/message.go
@@ -497,7 +497,6 @@ var errMessageHandler = func(c *client, e errorMessage) error {
 			}
 			c.pendingSubChange = nil
 		}
-		return nil
 	}
 
 	return fmt.Errorf("datav2stream: received unexpected error: %s", e.msg)

--- a/marketdata/stream/message.go
+++ b/marketdata/stream/message.go
@@ -478,12 +478,17 @@ var errMessageHandler = func(c *client, e errorMessage) error {
 		c.pendingSubChange = nil
 	}
 
-	c.logger.Warnf("datav2stream: got error from server: %+v", e)
-	if e.code == 0 || e.msg == "" {
+	if e.code != 0 && e.msg != "" {
+		c.logger.Warnf("datav2stream: got error from server: %s", e)
+		return nil
+	}
+	if e.code == 0 && e.msg == "" {
+		return fmt.Errorf("datav2stream: received unexpected error: no code or msg")
+	}
+	if e.code == 0 {
 		return fmt.Errorf("datav2stream: received unexpected error: %s", e.msg)
 	}
-
-	return nil
+	return fmt.Errorf("datav2stream: received unexpected error: %d", e.code)
 }
 
 func (c *client) handleErrorMessage(d *msgpack.Decoder, n int) error {

--- a/marketdata/stream/subscription.go
+++ b/marketdata/stream/subscription.go
@@ -1,31 +1,10 @@
 package stream
 
 import (
-	"errors"
 	"time"
 
 	"github.com/vmihailenco/msgpack/v5"
 )
-
-// ErrSubscriptionChangeBeforeConnect is returned when the client attempts to change subscriptions before
-// calling Connect
-var ErrSubscriptionChangeBeforeConnect = errors.New("subscription change attempted before calling Connect")
-
-// ErrSubscriptionChangeAfterTerminated is returned when client attempts to change subscriptions after
-// the client has been terminated
-var ErrSubscriptionChangeAfterTerminated = errors.New("subscription change after client termination")
-
-// ErrSubscriptionChangeAlreadyInProgress is returned when a subscription change is called concurrently
-// with another
-var ErrSubscriptionChangeAlreadyInProgress = errors.New("subscription change already in progress")
-
-// ErrSubscriptionChangeInterrupted is returned when a subscription change was in progress when the client
-// has terminated
-var ErrSubscriptionChangeInterrupted = errors.New("subscription change interrupted by client termination")
-
-// ErrSubscriptionChangeTimeout is returned when the server does not return a proper
-// subscription response after a subscription change request.
-var ErrSubscriptionChangeTimeout = errors.New("subscription change timeout")
 
 type subChangeRequest struct {
 	msg    []byte

--- a/marketdata/stream/subscription.go
+++ b/marketdata/stream/subscription.go
@@ -27,9 +27,6 @@ var ErrSubscriptionChangeInterrupted = errors.New("subscription change interrupt
 // subscription response after a subscription change request.
 var ErrSubscriptionChangeTimeout = errors.New("subscription change timeout")
 
-// ErrSubscriptionChangeTimeout is returned when a subscription change is invalid for the feed.
-var ErrSubscriptionChangeInvalidForFeed = errors.New("subscription change invalid for feed")
-
 type subChangeRequest struct {
 	msg    []byte
 	result chan error


### PR DESCRIPTION
Big fix: 
- certain errors were not logged with an established connection (important one being 407: slow client)

Small fix:
- handle insufficient scope as irrecoverable