### PR TITLE
Added GetCryptoSnapshot()

### DIFF
--- a/marketdata/entities.go
+++ b/marketdata/entities.go
@@ -202,6 +202,15 @@ type CryptoXBBO struct {
 	AskSize     float64   `json:"as"`
 }
 
+// CryptoSnapshot is a snapshot of a crypto symbol
+type CryptoSnapshot struct {
+	LatestTrade  *CryptoTrade `json:"latestTrade"`
+	LatestQuote  *CryptoQuote `json:"latestQuote"`
+	MinuteBar    *CryptoBar   `json:"minuteBar"`
+	DailyBar     *CryptoBar   `json:"dailyBar"`
+	PrevDailyBar *CryptoBar   `json:"prevDailyBar"`
+}
+
 type tradeResponse struct {
 	Symbol        string  `json:"symbol"`
 	NextPageToken *string `json:"next_page_token"`

--- a/marketdata/rest.go
+++ b/marketdata/rest.go
@@ -1210,7 +1210,7 @@ func (c *client) GetLatestCryptoXBBO(symbol string, exchanges []string) (*Crypto
 	return &latestXBBOResp.XBBO, nil
 }
 
-// GetCryptoSnapshot returns the snapshot for a given crypto symbol
+// GetCryptoSnapshot returns the snapshot for a given crypto symbol on the given exhange
 func (c *client) GetCryptoSnapshot(symbol string, exchange string) (*CryptoSnapshot, error) {
 	u, err := url.Parse(fmt.Sprintf("%s/%s/%s/snapshot", c.opts.BaseURL, cryptoPrefix, symbol))
 	if err != nil {
@@ -1227,7 +1227,6 @@ func (c *client) GetCryptoSnapshot(symbol string, exchange string) (*CryptoSnaps
 	}
 
 	var snapshot CryptoSnapshot
-
 	if err = unmarshal(resp, &snapshot); err != nil {
 		return nil, err
 	}

--- a/marketdata/rest.go
+++ b/marketdata/rest.go
@@ -47,6 +47,7 @@ type Client interface {
 	GetLatestCryptoTrade(symbol, exchange string) (*CryptoTrade, error)
 	GetLatestCryptoQuote(symbol, exchange string) (*CryptoQuote, error)
 	GetLatestCryptoXBBO(symbol string, exchanges []string) (*CryptoXBBO, error)
+	GetCryptoSnapshot(symbol string, exchange string) (*CryptoSnapshot, error)
 }
 
 // ClientOpts contains options for the alpaca marketdata client.
@@ -1209,6 +1210,31 @@ func (c *client) GetLatestCryptoXBBO(symbol string, exchanges []string) (*Crypto
 	return &latestXBBOResp.XBBO, nil
 }
 
+// GetCryptoSnapshot returns the snapshot for a given crypto symbol
+func (c *client) GetCryptoSnapshot(symbol string, exchange string) (*CryptoSnapshot, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/%s/%s/snapshot", c.opts.BaseURL, cryptoPrefix, symbol))
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	q.Set("exchange", exchange)
+	u.RawQuery = q.Encode()
+
+	resp, err := c.get(u)
+	if err != nil {
+		return nil, err
+	}
+
+	var snapshot CryptoSnapshot
+
+	if err = unmarshal(resp, &snapshot); err != nil {
+		return nil, err
+	}
+
+	return &snapshot, nil
+}
+
 // GetTrades returns the trades for the given symbol. It blocks until all the trades are collected.
 // If you want to process the incoming trades instantly, use GetTradesAsync instead!
 func GetTrades(symbol string, params GetTradesParams) ([]Trade, error) {
@@ -1376,6 +1402,11 @@ func GetLatestCryptoQuote(symbol, exchange string) (*CryptoQuote, error) {
 // GetLatestCryptoXBBO returns the latest quote for a given crypto symbol on the given exhange
 func GetLatestCryptoXBBO(symbol string, exchanges []string) (*CryptoXBBO, error) {
 	return DefaultClient.GetLatestCryptoXBBO(symbol, exchanges)
+}
+
+// GetCryptoSnapshot returns the snapshot for a given crypto symbol.
+func GetCryptoSnapshot(symbol string, exchange string) (*CryptoSnapshot, error) {
+	return DefaultClient.GetCryptoSnapshot(symbol, exchange)
 }
 
 func (c *client) get(u *url.URL) (*http.Response, error) {

--- a/marketdata/rest_test.go
+++ b/marketdata/rest_test.go
@@ -748,3 +748,70 @@ func TestLatestCryptoXBBO(t *testing.T) {
 		AskSize:     11.8787,
 	}, *got)
 }
+
+func TestCryptoSnapshot(t *testing.T) {
+	c := testClient()
+
+	// successful
+	c.do = mockResp(`{"symbol":"ETHUSD","latestTrade":{"t":"2021-12-08T19:26:58.703892Z","x":"CBSE","p":4393.18,"s":0.04299154,"tks":"S","i":191026243},"latestQuote":{"t":"2021-12-08T21:39:50.999Z","x":"CBSE","bp":4405.27,"bs":0.32420683,"ap":4405.28,"as":0.54523826},"minuteBar":{"t":"2021-12-08T19:26:00Z","x":"CBSE","o":4393.62,"h":4396.45,"l":4390.81,"c":4393.18,"v":132.02049802,"n":278,"vw":4393.9907155981},"dailyBar":{"t":"2021-12-08T06:00:00Z","x":"CBSE","o":4329.11,"h":4455.62,"l":4231.55,"c":4393.18,"v":95466.0903448,"n":186155,"vw":4367.7642299555},"prevDailyBar":{"t":"2021-12-07T06:00:00Z","x":"CBSE","o":4350.15,"h":4433.99,"l":4261.39,"c":4329.11,"v":152391.30635034,"n":326203,"vw":4344.2956259855}}`)
+	got, err := c.GetCryptoSnapshot("ETHUSD", "CBSE")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, CryptoSnapshot{
+		LatestTrade: &CryptoTrade{
+			ID:        191026243,
+			Exchange:  "CBSE",
+			Price:     4393.18,
+			Size:      0.04299154,
+			TakerSide: "S",
+			Timestamp: time.Date(2021, 12, 8, 19, 26, 58, 703892000, time.UTC),
+		},
+		LatestQuote: &CryptoQuote{
+			Exchange:  "CBSE",
+			BidPrice:  4405.27,
+			BidSize:   0.32420683,
+			AskPrice:  4405.28,
+			AskSize:   0.54523826,
+			Timestamp: time.Date(2021, 12, 8, 21, 39, 50, 999000000, time.UTC),
+		},
+		MinuteBar: &CryptoBar{
+			Exchange:   "CBSE",
+			Open:       4393.62,
+			High:       4396.45,
+			Low:        4390.81,
+			Close:      4393.18,
+			Volume:     132.02049802,
+			TradeCount: 278,
+			VWAP:       4393.9907155981,
+			Timestamp:  time.Date(2021, 12, 8, 19, 26, 0, 0, time.UTC),
+		},
+		DailyBar: &CryptoBar{
+			Exchange:   "CBSE",
+			Open:       4329.11,
+			High:       4455.62,
+			Low:        4231.55,
+			Close:      4393.18,
+			Volume:     95466.0903448,
+			TradeCount: 186155,
+			VWAP:       4367.7642299555,
+			Timestamp:  time.Date(2021, 12, 8, 6, 0, 0, 0, time.UTC),
+		},
+		PrevDailyBar: &CryptoBar{
+			Exchange:   "CBSE",
+			Open:       4350.15,
+			High:       4433.99,
+			Low:        4261.39,
+			Close:      4329.11,
+			Volume:     152391.30635034,
+			TradeCount: 326203,
+			VWAP:       4344.2956259855,
+			Timestamp:  time.Date(2021, 12, 7, 6, 0, 0, 0, time.UTC),
+		},
+	}, *got)
+
+	// api failure
+	c.do = mockErrResp()
+	got, err = c.GetCryptoSnapshot("ETHUSD", "CBSE")
+	assert.Error(t, err)
+	assert.Nil(t, got)
+}


### PR DESCRIPTION
## Context
Add method to query crypto snapshot endpoint.

## TODO
- ~Add unit test~

## Test result
```
css, err := marketdata.GetCryptoSnapshot("ETHUSD", "CBSE")

(dlv) p css 
*github.com/alpacahq/alpaca-trade-api-go/v2/marketdata.CryptoSnapshot {                                                                                                                                    
        LatestTrade: *github.com/alpacahq/alpaca-trade-api-go/v2/marketdata.CryptoTrade {                                                                                                                  
                Timestamp: (*time.Time)(0xc000382730),                                                                                                                                                     
                Price: 4393.18,                                                                                                                                                                            
                Size: 0.04299154,                                                                                                                                                                          
                Exchange: "CBSE",                                                                                                                                                                          
                ID: 191026243,                                                                                                                                                                             
                TakerSide: "S",},                                                                                                                                                                          
        LatestQuote: *github.com/alpacahq/alpaca-trade-api-go/v2/marketdata.CryptoQuote {                                                                                                                  
                Timestamp: (*time.Time)(0xc000382780),                                                                                                                                                     
                Exchange: "CBSE",                                                                                                                                                                          
                BidPrice: 4400.64,                                                                                                                                                                         
                BidSize: 5.67990727,                                                                                                                                                                       
                AskPrice: 4400.65,                                                                                                                                                                         
                AskSize: 0.72309233,},                                                                                                                                                                     
        MinuteBar: *github.com/alpacahq/alpaca-trade-api-go/v2/marketdata.CryptoBar {                                                                                                                      
                Timestamp: (*time.Time)(0xc000380420),                                                                                                                                                     
                Exchange: "CBSE",                                                                                                                                                                          
                Open: 4393.62,                                                                                                                                                                             
                High: 4396.45,                                                                                                                                                                             
                Low: 4390.81,                                                                                                                                                                              
                Close: 4393.18,                                                                                                                                                                            
                Volume: 132.02049802,                                                                                                                                                                      
                TradeCount: 278,                                                                                                                                                                           
                VWAP: 4393.9907155981,},                                                                                                                                                                   
        DailyBar: *github.com/alpacahq/alpaca-trade-api-go/v2/marketdata.CryptoBar {                                                                                                                       
                Timestamp: (*time.Time)(0xc000380480),                                                                                                                                                     
                Exchange: "CBSE",                                                                                                                                                                          
                Open: 4329.11,                                                                                                                                                                             
                High: 4455.62,                                                                                                                                                                             
                Low: 4231.55,                                                                                                                                                                              
                Close: 4393.18,                                                                                                                                                                            
                Volume: 95466.0903448,                                                                                                                                                                     
                TradeCount: 186155,                                                                                                                                                                        
                VWAP: 4367.7642299555,},                                                                                                                                                                   
        PrevDailyBar: *github.com/alpacahq/alpaca-trade-api-go/v2/marketdata.CryptoBar {                                                                                                                   
                Timestamp: (*time.Time)(0xc0003804e0),                                                                                                                                                     
                Exchange: "CBSE",                                                                                                                                                                          
                Open: 4350.15,                                                                                                                                                                             
                High: 4433.99,                                                                                                                                                                             
                Low: 4261.39,                                                                                                                                                                              
                Close: 4329.11,                                                                                                                                                                            
                Volume: 152391.30635034,                                                                                                                                                                   
                TradeCount: 326203,                                                                                                                                                                        
                VWAP: 4344.2956259855,},}       
```