### PR TITLE
Feature/list orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 .vscode
+.idea
 vendor

--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -234,6 +234,16 @@ type AccountActivitiesRequest struct {
 	PageSize      *int       `json:"page_size"`
 }
 
+type ListOrdersRequest struct {
+	Status    *string    `json:"status"`
+	After     *time.Time `json:"after"`
+	Until     *time.Time `json:"until"`
+	Limit     *int       `json:"limit"`
+	Direction *string    `json:"direction"`
+	Nested    *bool      `json:"nested"`
+	Symbols   *string    `json:"symbols"`
+}
+
 type Side string
 
 const (

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -29,7 +29,7 @@ type Client interface {
 	GetClock() (*Clock, error)
 	GetCalendar(start, end *string) ([]CalendarDay, error)
 	ListOrders(status *string, until *time.Time, limit *int, nested *bool) ([]Order, error)
-	ListOrdersV2(req ListOrderRequest) ([]Order, error)
+	ListOrdersV2(req ListOrdersRequest) ([]Order, error)
 	PlaceOrder(req PlaceOrderRequest) (*Order, error)
 	GetOrder(orderID string) (*Order, error)
 	GetOrderByClientOrderID(clientOrderID string) (*Order, error)
@@ -473,7 +473,7 @@ func (c *client) ListOrders(status *string, until *time.Time, limit *int, nested
 
 // ListOrdersV2 returns the list of orders for an account,
 // filtered by the input parameters.
-func (c *client) ListOrdersV2(req ListOrderRequest) ([]Order, error) {
+func (c *client) ListOrdersV2(req ListOrdersRequest) ([]Order, error) {
 	urlString := fmt.Sprintf("%s/%s/orders", c.opts.BaseURL, apiVersion)
 	if req.Nested != nil {
 		urlString += fmt.Sprintf("?nested=%v", *req.Nested)

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -29,6 +29,7 @@ type Client interface {
 	GetClock() (*Clock, error)
 	GetCalendar(start, end *string) ([]CalendarDay, error)
 	ListOrders(status *string, until *time.Time, limit *int, nested *bool) ([]Order, error)
+	ListOrdersV2(req ListOrderRequest) ([]Order, error)
 	PlaceOrder(req PlaceOrderRequest) (*Order, error)
 	GetOrder(orderID string) (*Order, error)
 	GetOrderByClientOrderID(clientOrderID string) (*Order, error)
@@ -429,6 +430,7 @@ func (c *client) GetCalendar(start, end *string) ([]CalendarDay, error) {
 
 // ListOrders returns the list of orders for an account,
 // filtered by the input parameters.
+// Deprecated: This function is deprecated in favor of ListOrdersV2 which contains all possible parameters.
 func (c *client) ListOrders(status *string, until *time.Time, limit *int, nested *bool) ([]Order, error) {
 	urlString := fmt.Sprintf("%s/%s/orders", c.opts.BaseURL, apiVersion)
 	if nested != nil {
@@ -451,6 +453,60 @@ func (c *client) ListOrders(status *string, until *time.Time, limit *int, nested
 
 	if limit != nil {
 		q.Set("limit", strconv.FormatInt(int64(*limit), 10))
+	}
+
+	u.RawQuery = q.Encode()
+
+	resp, err := c.get(u)
+	if err != nil {
+		return nil, err
+	}
+
+	orders := []Order{}
+
+	if err = unmarshal(resp, &orders); err != nil {
+		return nil, err
+	}
+
+	return orders, nil
+}
+
+// ListOrdersV2 returns the list of orders for an account,
+// filtered by the input parameters.
+func (c *client) ListOrdersV2(req ListOrderRequest) ([]Order, error) {
+	urlString := fmt.Sprintf("%s/%s/orders", c.opts.BaseURL, apiVersion)
+	if req.Nested != nil {
+		urlString += fmt.Sprintf("?nested=%v", *req.Nested)
+	}
+	u, err := url.Parse(urlString)
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+
+	if req.Status != nil {
+		q.Set("status", *req.Status)
+	}
+
+	if req.After != nil {
+		q.Set("after", req.After.Format(time.RFC3339))
+	}
+
+	if req.Until != nil {
+		q.Set("until", req.Until.Format(time.RFC3339))
+	}
+
+	if req.Limit != nil {
+		q.Set("limit", strconv.FormatInt(int64(*req.Limit), 10))
+	}
+
+	if req.Direction != nil {
+		q.Set("direction", *req.Direction)
+	}
+
+	if req.Symbols != nil {
+		q.Set("symbols", *req.Symbols)
 	}
 
 	u.RawQuery = q.Encode()

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -171,6 +171,36 @@ func TestListOrders(t *testing.T) {
 	assert.Nil(t, orders)
 }
 
+func TestListOrdersV2(t *testing.T) {
+	c := testClient()
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		orders := []Order{
+			{
+				ID: "some_id",
+			},
+		}
+		return &http.Response{
+			Body: genBody(orders),
+		}, nil
+	}
+
+	req := ListOrdersRequest{}
+
+	orders, err := c.ListOrdersV2(req)
+	require.NoError(t, err)
+	require.Len(t, orders, 1)
+	assert.Equal(t, "some_id", orders[0].ID)
+
+	// api failure
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		return &http.Response{}, fmt.Errorf("fail")
+	}
+
+	orders, err = c.ListOrdersV2(req)
+	require.Error(t, err)
+	assert.Nil(t, orders)
+}
+
 func TestPlaceOrder(t *testing.T) {
 	c := testClient()
 	// successful (w/ Qty)

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -171,9 +171,19 @@ func TestListOrders(t *testing.T) {
 	assert.Nil(t, orders)
 }
 
-func TestListOrdersV2(t *testing.T) {
+func TestListOrdersWithEmptyRequest(t *testing.T) {
 	c := testClient()
 	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "api.alpaca.markets", req.URL.Host)
+		assert.Equal(t, "/v2/orders", req.URL.Path)
+		assert.Equal(t, "", req.URL.Query().Get("status"))
+		assert.Equal(t, "", req.URL.Query().Get("after"))
+		assert.Equal(t, "", req.URL.Query().Get("until"))
+		assert.Equal(t, "", req.URL.Query().Get("limit"))
+		assert.Equal(t, "", req.URL.Query().Get("direction"))
+		assert.Equal(t, "", req.URL.Query().Get("nested"))
+		assert.Equal(t, "", req.URL.Query().Get("symbols"))
+
 		orders := []Order{
 			{
 				ID: "some_id",
@@ -186,7 +196,54 @@ func TestListOrdersV2(t *testing.T) {
 
 	req := ListOrdersRequest{}
 
-	orders, err := c.ListOrdersV2(req)
+	orders, err := c.ListOrdersWithRequest(req)
+	require.NoError(t, err)
+	require.Len(t, orders, 1)
+	assert.Equal(t, "some_id", orders[0].ID)
+}
+
+func TestListOrdersWithRequest(t *testing.T) {
+	c := testClient()
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "api.alpaca.markets", req.URL.Host)
+		assert.Equal(t, "/v2/orders", req.URL.Path)
+		assert.Equal(t, "all", req.URL.Query().Get("status"))
+		assert.Equal(t, "2021-04-03T00:00:00Z", req.URL.Query().Get("after"))
+		assert.Equal(t, "2021-04-04T05:00:00Z", req.URL.Query().Get("until"))
+		assert.Equal(t, "2", req.URL.Query().Get("limit"))
+		assert.Equal(t, "asc", req.URL.Query().Get("direction"))
+		assert.Equal(t, "true", req.URL.Query().Get("nested"))
+		assert.Equal(t, "AAPL,TSLA", req.URL.Query().Get("symbols"))
+
+		orders := []Order{
+			{
+				ID: "some_id",
+			},
+		}
+		return &http.Response{
+			Body: genBody(orders),
+		}, nil
+	}
+
+	status := "all"
+	after, _ := time.Parse(time.RFC3339, "2021-04-03T00:00:00Z")
+	until, _ := time.Parse(time.RFC3339, "2021-04-04T05:00:00Z")
+	limit := 2
+	direction := "asc"
+	nested := true
+	symbols := "AAPL,TSLA"
+
+	req := ListOrdersRequest{
+		Status:    &status,
+		After:     &after,
+		Until:     &until,
+		Limit:     &limit,
+		Direction: &direction,
+		Nested:    &nested,
+		Symbols:   &symbols,
+	}
+
+	orders, err := c.ListOrdersWithRequest(req)
 	require.NoError(t, err)
 	require.Len(t, orders, 1)
 	assert.Equal(t, "some_id", orders[0].ID)
@@ -196,7 +253,7 @@ func TestListOrdersV2(t *testing.T) {
 		return &http.Response{}, fmt.Errorf("fail")
 	}
 
-	orders, err = c.ListOrdersV2(req)
+	orders, err = c.ListOrdersWithRequest(req)
 	require.Error(t, err)
 	assert.Nil(t, orders)
 }


### PR DESCRIPTION
In this PR I added the ListOrdersWithRequest function because the ListOrders function that is already present does not include all possible parameters and fixing this directly in the function would be a breaking change.

As requested by this issue: https://github.com/alpacahq/alpaca-trade-api-go/issues/108