### PR TITLE
Add GetOrderWithRequest to allow getting nested orders

### DIFF
--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -244,6 +244,11 @@ type ListOrdersRequest struct {
 	Symbols   *string    `json:"symbols"`
 }
 
+type GetOrderRequest struct {
+	ID     string `json:"id"`
+	Nested *bool  `json:"nested"`
+}
+
 type Side string
 
 const (

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -349,7 +349,7 @@ func TestGetOrder(t *testing.T) {
 
 func TestGetOrderWithRequest(t *testing.T) {
 	c := testClient()
-	// successful
+	// successful (nested true)
 	c.do = func(c *client, req *http.Request) (*http.Response, error) {
 		assert.Equal(t, "true", req.URL.Query().Get("nested"))
 		order := Order{
@@ -362,6 +362,38 @@ func TestGetOrderWithRequest(t *testing.T) {
 
 	nested := true
 	order, err := c.GetOrderWithRequest(GetOrderRequest{ID: "some_order_id", Nested: &nested})
+	require.NoError(t, err)
+	assert.NotNil(t, order)
+
+	// successful (nested false)
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "false", req.URL.Query().Get("nested"))
+		order := Order{
+			ID: "some_order_id",
+		}
+		return &http.Response{
+			Body: genBody(order),
+		}, nil
+	}
+
+	nested = false
+	order, err = c.GetOrderWithRequest(GetOrderRequest{ID: "some_order_id", Nested: &nested})
+	require.NoError(t, err)
+	assert.NotNil(t, order)
+
+	// successful (nested nil)
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		assert.False(t, req.URL.Query().Has("nested"))
+		order := Order{
+			ID: "some_order_id",
+		}
+		return &http.Response{
+			Body: genBody(order),
+		}, nil
+	}
+
+	nested = false
+	order, err = c.GetOrderWithRequest(GetOrderRequest{ID: "some_order_id", Nested: nil})
 	require.NoError(t, err)
 	assert.NotNil(t, order)
 

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -347,6 +347,34 @@ func TestGetOrder(t *testing.T) {
 	assert.Nil(t, order)
 }
 
+func TestGetOrderWithRequest(t *testing.T) {
+	c := testClient()
+	// successful
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "true", req.URL.Query().Get("nested"))
+		order := Order{
+			ID: "some_order_id",
+		}
+		return &http.Response{
+			Body: genBody(order),
+		}, nil
+	}
+
+	nested := true
+	order, err := c.GetOrderWithRequest(GetOrderRequest{ID: "some_order_id", Nested: &nested})
+	require.NoError(t, err)
+	assert.NotNil(t, order)
+
+	// api failure
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		return &http.Response{}, fmt.Errorf("fail")
+	}
+
+	order, err = c.GetOrderWithRequest(GetOrderRequest{ID: "some_order_id"})
+	require.Error(t, err)
+	assert.Nil(t, order)
+}
+
 func TestGetOrderByClientOrderId(t *testing.T) {
 	c := testClient()
 	// successful


### PR DESCRIPTION
According to the Alpaca docs, the [Get an Order](https://alpaca.markets/docs/api-references/trading-api/orders/#get-an-order) endpoint allows requesting nested orders, so that we can get all the legs of an advanced order. The current SDK does not allow this. This PR fixes that by adding a `GetOrderRequest` struct and a `GetOrderWithRequest` function to the client that allows specifying values on the request to get an order (for now, only the `Nested *bool` value).