### PR TITLE
Add (dis)connect callbacks to market data stream client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,19 +3,17 @@ module github.com/alpacahq/alpaca-trade-api-go/v2
 go 1.14
 
 require (
-	cloud.google.com/go v0.99.0 // indirect
+	cloud.google.com/go v0.99.0
 	github.com/RobinUS2/golang-moving-average v1.0.0
 	github.com/gobwas/ws v1.0.3 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/klauspost/compress v1.11.0 // indirect
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/shopspring/decimal v1.2.0
 	github.com/stretchr/testify v1.7.0
 	github.com/vmihailenco/msgpack/v5 v5.3.0
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,10 +121,10 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -137,10 +137,10 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.3 h1:x95R7cp+rSeeqAMI2knLtQ0DKlaBhv2NrtrOvafPHRo=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -366,8 +366,6 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
-golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -586,10 +584,10 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
-google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/marketdata/stream/client.go
+++ b/marketdata/stream/client.go
@@ -107,8 +107,8 @@ type client struct {
 
 	reconnectLimit     int
 	reconnectDelay     time.Duration
-	connectCallback    func() error
-	disconnectCallback func() error
+	connectCallback    func()
+	disconnectCallback func()
 	processorCount     int
 	bufferSize         int
 	connectOnce        sync.Once
@@ -368,7 +368,7 @@ func (c *client) maintainConnection(ctx context.Context, u url.URL, initialResul
 		// If a disconnect/connect callback is running then wait until it finishes or times out.
 		timeout := time.Second
 		if waitTimeout(&callbackWaitGroup, timeout) {
-			c.logger.Warnf("datav2stream: timed out after waiting one second for connect/disconnect callbacks to return")
+			c.logger.Warnf("datav2stream: timed out after waiting %s for connect/disconnect callbacks to return", timeout)
 		}
 	}()
 
@@ -432,9 +432,7 @@ func (c *client) maintainConnection(ctx context.Context, u url.URL, initialResul
 				callbackWaitGroup.Add(1)
 				go func() {
 					defer callbackWaitGroup.Done()
-					if err := c.connectCallback(); err != nil {
-						c.logger.Warnf("datav2stream: connect callback failed, error: %v", err)
-					}
+					c.connectCallback()
 				}()
 			}
 
@@ -466,9 +464,7 @@ func (c *client) maintainConnection(ctx context.Context, u url.URL, initialResul
 				callbackWaitGroup.Add(1)
 				go func() {
 					defer callbackWaitGroup.Done()
-					if err := c.disconnectCallback(); err != nil {
-						c.logger.Warnf("datav2stream: disconnect callback failed, error: %v", err)
-					}
+					c.disconnectCallback()
 				}()
 			}
 		}

--- a/marketdata/stream/client.go
+++ b/marketdata/stream/client.go
@@ -105,17 +105,19 @@ type client struct {
 	key     string
 	secret  string
 
-	reconnectLimit int
-	reconnectDelay time.Duration
-	processorCount int
-	bufferSize     int
-	connectOnce    sync.Once
-	connectCalled  bool
-	hasTerminated  bool
-	terminatedChan chan error
-	conn           conn
-	in             chan []byte
-	subChanges     chan []byte
+	reconnectLimit     int
+	reconnectDelay     time.Duration
+	connectCallback    func() error
+	disconnectCallback func() error
+	processorCount     int
+	bufferSize         int
+	connectOnce        sync.Once
+	connectCalled      bool
+	hasTerminated      bool
+	terminatedChan     chan error
+	conn               conn
+	in                 chan []byte
+	subChanges         chan []byte
 
 	sub subscriptions
 
@@ -141,6 +143,8 @@ func (c *client) configure(o options) {
 	c.secret = o.secret
 	c.reconnectLimit = o.reconnectLimit
 	c.reconnectDelay = o.reconnectDelay
+	c.connectCallback = o.connectCallback
+	c.disconnectCallback = o.disconnectCallback
 	c.processorCount = o.processorCount
 	c.bufferSize = o.bufferSize
 	c.sub = o.sub
@@ -347,6 +351,7 @@ func (c *client) maintainConnection(ctx context.Context, u url.URL, initialResul
 	failedAttemptsInARow := 0
 	connectedAtLeastOnce := false
 
+	callbackWaitGroup := sync.WaitGroup{}
 	defer func() {
 		// If there is a pending sub change we should terminate that
 		c.pendingSubChangeMutex.Lock()
@@ -359,6 +364,11 @@ func (c *client) maintainConnection(ctx context.Context, u url.URL, initialResul
 		// if we haven't connected at least once then Connected should close the channel
 		if connectedAtLeastOnce {
 			close(c.terminatedChan)
+		}
+		// If a disconnect/connect callback is running then wait until it finishes or times out.
+		timeout := time.Second
+		if waitTimeout(&callbackWaitGroup, timeout) {
+			c.logger.Warnf("datav2stream: timed out after waiting one second for connect/disconnect callbacks to return")
 		}
 	}()
 
@@ -417,6 +427,17 @@ func (c *client) maintainConnection(ctx context.Context, u url.URL, initialResul
 				continue
 			}
 			c.logger.Infof("datav2stream: finished connection setup")
+
+			if c.connectCallback != nil {
+				callbackWaitGroup.Add(1)
+				go func() {
+					defer callbackWaitGroup.Done()
+					if err := c.connectCallback(); err != nil {
+						c.logger.Warnf("datav2stream: connect callback failed, error: %v", err)
+					}
+				}()
+			}
+
 			connError = nil
 			if !connectedAtLeastOnce {
 				initialResultCh <- nil
@@ -440,7 +461,33 @@ func (c *client) maintainConnection(ctx context.Context, u url.URL, initialResul
 			} else {
 				c.logger.Warnf("datav2stream: connection lost")
 			}
+
+			if c.disconnectCallback != nil {
+				callbackWaitGroup.Add(1)
+				go func() {
+					defer callbackWaitGroup.Done()
+					if err := c.disconnectCallback(); err != nil {
+						c.logger.Warnf("datav2stream: disconnect callback failed, error: %v", err)
+					}
+				}()
+			}
 		}
+	}
+}
+
+// waitTimeout waits for the WaitGroup for the specified max timeout.
+// Returns true if waiting timed out.
+func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return false // completed normally
+	case <-time.After(timeout):
+		return true // timed out
 	}
 }
 

--- a/marketdata/stream/client_test.go
+++ b/marketdata/stream/client_test.go
@@ -243,8 +243,8 @@ func TestCallbacksCalledOnConnectAndDisconnect(t *testing.T) {
 			assert.Equal(t, 1, numConnectCalls)
 			assert.Equal(t, 0, numDisconnectCalls)
 
-			// Now force the stream to disconnect via context and assert disconnect is called after
-			// waiting a small amount of time to wait for the stream to shut down
+			// Now force the stream to disconnect via context and assert disconnect callback is
+			// called after waiting a small amount of time to wait for the stream to shut down.
 			cancel()
 			time.Sleep(100 * time.Millisecond)
 			assert.Equal(t, 1, numConnectCalls)

--- a/marketdata/stream/client_test.go
+++ b/marketdata/stream/client_test.go
@@ -210,9 +210,19 @@ func TestConnectSucceeds(t *testing.T) {
 func TestCallbacksCalledOnConnectAndDisconnect(t *testing.T) {
 	for _, tt := range tests {
 		numConnectCalls := 0
+		connects := make(chan struct{})
+		connectCallback := func() {
+			numConnectCalls++
+			connects <- struct{}{}
+		}
+
 		numDisconnectCalls := 0
-		connectCallback := func() { numConnectCalls++ }
-		disconnectCallback := func() { numDisconnectCalls++ }
+		disconnects := make(chan struct{})
+		disconnectCallback := func() {
+			numDisconnectCalls++
+			disconnects <- struct{}{}
+		}
+
 		t.Run(tt.name, func(t *testing.T) {
 			connection := newMockConn()
 			defer connection.close()
@@ -240,13 +250,23 @@ func TestCallbacksCalledOnConnectAndDisconnect(t *testing.T) {
 
 			err := c.Connect(ctx)
 			require.NoError(t, err)
+
+			select {
+			case <-connects:
+			case <-time.After(time.Second):
+				require.Fail(t, "connect callback was not called in time")
+			}
 			assert.Equal(t, 1, numConnectCalls)
 			assert.Equal(t, 0, numDisconnectCalls)
 
 			// Now force the stream to disconnect via context and assert disconnect callback is
 			// called after waiting a small amount of time to wait for the stream to shut down.
 			cancel()
-			time.Sleep(100 * time.Millisecond)
+			select {
+			case <-disconnects:
+			case <-time.After(time.Second):
+				require.Fail(t, "disconnect callback was not called in time")
+			}
 			assert.Equal(t, 1, numConnectCalls)
 			assert.Equal(t, 1, numDisconnectCalls)
 		})

--- a/marketdata/stream/options.go
+++ b/marketdata/stream/options.go
@@ -35,8 +35,8 @@ type options struct {
 	secret             string
 	reconnectLimit     int
 	reconnectDelay     time.Duration
-	connectCallback    func() error
-	disconnectCallback func() error
+	connectCallback    func()
+	disconnectCallback func()
 	processorCount     int
 	bufferSize         int
 	sub                subscriptions
@@ -108,7 +108,7 @@ func WithReconnectSettings(limit int, delay time.Duration) Option {
 // If the stream terminates and can't reconnect, the disconnect callback will timeout one second
 // after reaching the end of the stream's maintenance (if it is still running). This is to avoid
 // the callback blocking the parent thread.
-func WithConnectCallback(callback func() error) Option {
+func WithConnectCallback(callback func()) Option {
 	return newFuncOption(func(o *options) {
 		o.connectCallback = callback
 	})
@@ -118,7 +118,7 @@ func WithConnectCallback(callback func() error) Option {
 // If the stream is terminated and can't reconnect, the disconnect callback will timeout one second
 // after reaching the end of the stream's maintenance (if it is still running). This is to avoid
 // the callback blocking the parent thread.
-func WithDisconnectCallback(callback func() error) Option {
+func WithDisconnectCallback(callback func()) Option {
 	return newFuncOption(func(o *options) {
 		o.disconnectCallback = callback
 	})
@@ -170,16 +170,14 @@ func defaultStockOptions() *stockOptions {
 
 	return &stockOptions{
 		options: options{
-			logger:             DefaultLogger(),
-			baseURL:            baseURL,
-			key:                os.Getenv("APCA_API_KEY_ID"),
-			secret:             os.Getenv("APCA_API_SECRET_KEY"),
-			reconnectLimit:     20,
-			reconnectDelay:     150 * time.Millisecond,
-			connectCallback:    nil,
-			disconnectCallback: nil,
-			processorCount:     1,
-			bufferSize:         100000,
+			logger:         DefaultLogger(),
+			baseURL:        baseURL,
+			key:            os.Getenv("APCA_API_KEY_ID"),
+			secret:         os.Getenv("APCA_API_SECRET_KEY"),
+			reconnectLimit: 20,
+			reconnectDelay: 150 * time.Millisecond,
+			processorCount: 1,
+			bufferSize:     100000,
 			sub: subscriptions{
 				trades:       []string{},
 				quotes:       []string{},
@@ -323,16 +321,14 @@ func defaultCryptoOptions() *cryptoOptions {
 
 	return &cryptoOptions{
 		options: options{
-			logger:             DefaultLogger(),
-			baseURL:            baseURL,
-			key:                os.Getenv("APCA_API_KEY_ID"),
-			secret:             os.Getenv("APCA_API_SECRET_KEY"),
-			reconnectLimit:     20,
-			reconnectDelay:     150 * time.Millisecond,
-			connectCallback:    nil,
-			disconnectCallback: nil,
-			processorCount:     1,
-			bufferSize:         100000,
+			logger:         DefaultLogger(),
+			baseURL:        baseURL,
+			key:            os.Getenv("APCA_API_KEY_ID"),
+			secret:         os.Getenv("APCA_API_SECRET_KEY"),
+			reconnectLimit: 20,
+			reconnectDelay: 150 * time.Millisecond,
+			processorCount: 1,
+			bufferSize:     100000,
 			sub: subscriptions{
 				trades:      []string{},
 				quotes:      []string{},
@@ -439,16 +435,14 @@ type newsOptions struct {
 func defaultNewsOptions() *newsOptions {
 	return &newsOptions{
 		options: options{
-			logger:             DefaultLogger(),
-			baseURL:            "https://stream.data.alpaca.markets/v1beta1/news",
-			key:                os.Getenv("APCA_API_KEY_ID"),
-			secret:             os.Getenv("APCA_API_SECRET_KEY"),
-			reconnectLimit:     20,
-			reconnectDelay:     150 * time.Millisecond,
-			connectCallback:    nil,
-			disconnectCallback: nil,
-			processorCount:     1,
-			bufferSize:         100,
+			logger:         DefaultLogger(),
+			baseURL:        "https://stream.data.alpaca.markets/v1beta1/news",
+			key:            os.Getenv("APCA_API_KEY_ID"),
+			secret:         os.Getenv("APCA_API_SECRET_KEY"),
+			reconnectLimit: 20,
+			reconnectDelay: 150 * time.Millisecond,
+			processorCount: 1,
+			bufferSize:     100,
 			sub: subscriptions{
 				news: []string{},
 			},

--- a/marketdata/stream/options.go
+++ b/marketdata/stream/options.go
@@ -105,7 +105,7 @@ func WithReconnectSettings(limit int, delay time.Duration) Option {
 }
 
 // WithConnectCallback runs the callback function after the streaming connection is setup.
-// If the stream terminates and can't reconnect, the disconnect callback will timeout one second
+// If the stream terminates and can't reconnect, the connect callback will timeout one second
 // after reaching the end of the stream's maintenance (if it is still running). This is to avoid
 // the callback blocking the parent thread.
 func WithConnectCallback(callback func()) Option {

--- a/marketdata/stream/options_test.go
+++ b/marketdata/stream/options_test.go
@@ -33,6 +33,8 @@ func TestDefaultOptions(t *testing.T) {
 			assert.EqualValues(t, "testsecret", o.secret)
 			assert.EqualValues(t, 20, o.reconnectLimit)
 			assert.EqualValues(t, 150*time.Millisecond, o.reconnectDelay)
+			assert.EqualValues(t, nil, o.connectCallback)
+			assert.EqualValues(t, nil, o.disconnectCallback)
 			assert.EqualValues(t, 1, o.processorCount)
 			assert.EqualValues(t, 100000, o.bufferSize)
 			assert.EqualValues(t, []string{}, o.sub.trades)

--- a/marketdata/stream/options_test.go
+++ b/marketdata/stream/options_test.go
@@ -33,8 +33,6 @@ func TestDefaultOptions(t *testing.T) {
 			assert.EqualValues(t, "testsecret", o.secret)
 			assert.EqualValues(t, 20, o.reconnectLimit)
 			assert.EqualValues(t, 150*time.Millisecond, o.reconnectDelay)
-			assert.EqualValues(t, nil, o.connectCallback)
-			assert.EqualValues(t, nil, o.disconnectCallback)
 			assert.EqualValues(t, 1, o.processorCount)
 			assert.EqualValues(t, 100000, o.bufferSize)
 			assert.EqualValues(t, []string{}, o.sub.trades)


### PR DESCRIPTION
Allows the market data streaming client to supply a callback function as an option to run on connect/disconnect from the stream. The primary use case is for supporting monitoring and alerting workflows (e.g. prometheus metrics).