### PR TITLE
Fixed invalid date formats for GetAccountActivities

### DIFF
--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -223,13 +223,13 @@ func (c *client) GetAccountActivities(activityType *string, opts *AccountActivit
 			q.Set("activity_types", strings.Join(*opts.ActivityTypes, ","))
 		}
 		if opts.Date != nil {
-			q.Set("date", opts.Date.String())
+			q.Set("date", opts.Date.Format(time.RFC3339))
 		}
 		if opts.Until != nil {
-			q.Set("until", opts.Until.String())
+			q.Set("until", opts.Until.Format(time.RFC3339))
 		}
 		if opts.After != nil {
-			q.Set("after", opts.After.String())
+			q.Set("after", opts.After.Format(time.RFC3339))
 		}
 		if opts.Direction != nil {
 			q.Set("direction", *opts.Direction)

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -223,13 +223,13 @@ func (c *client) GetAccountActivities(activityType *string, opts *AccountActivit
 			q.Set("activity_types", strings.Join(*opts.ActivityTypes, ","))
 		}
 		if opts.Date != nil {
-			q.Set("date", opts.Date.UTC().Format(time.RFC3339))
+			q.Set("date", opts.Date.UTC().Format(time.RFC3339Nano))
 		}
 		if opts.Until != nil {
-			q.Set("until", opts.Until.UTC().Format(time.RFC3339))
+			q.Set("until", opts.Until.UTC().Format(time.RFC3339Nano))
 		}
 		if opts.After != nil {
-			q.Set("after", opts.After.UTC().Format(time.RFC3339))
+			q.Set("after", opts.After.UTC().Format(time.RFC3339Nano))
 		}
 		if opts.Direction != nil {
 			q.Set("direction", *opts.Direction)

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -223,13 +223,13 @@ func (c *client) GetAccountActivities(activityType *string, opts *AccountActivit
 			q.Set("activity_types", strings.Join(*opts.ActivityTypes, ","))
 		}
 		if opts.Date != nil {
-			q.Set("date", opts.Date.Format(time.RFC3339))
+			q.Set("date", opts.Date.UTC().Format(time.RFC3339))
 		}
 		if opts.Until != nil {
-			q.Set("until", opts.Until.Format(time.RFC3339))
+			q.Set("until", opts.Until.UTC().Format(time.RFC3339))
 		}
 		if opts.After != nil {
-			q.Set("after", opts.After.Format(time.RFC3339))
+			q.Set("after", opts.After.UTC().Format(time.RFC3339))
 		}
 		if opts.Direction != nil {
 			q.Set("direction", *opts.Direction)

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -608,7 +608,7 @@ func TestGetAccountActivities(t *testing.T) {
 		getQuery := req.URL.Query()
 
 		assert.Equal(t, "/v2/account/activities/DIV", req.URL.Path)
-		assert.Equal(t, "2019-01-01T07:00:00.0000001Z", getQuery.Get("after"))
+		assert.Equal(t, "2019-01-01T00:00:00.0000001Z", getQuery.Get("after"))
 		assert.Equal(t, "10", getQuery.Get("page_size"))
 
 		nta := []map[string]interface{}{

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -602,6 +602,40 @@ func TestGetAccountActivities(t *testing.T) {
 	_, err = c.GetAccountActivities(&dividendsActivityType, nil)
 	assert.NotNil(t, err)
 	assert.EqualError(t, &APIError{Code: 500, Message: "internal server error"}, "internal server error")
+
+	// test filter by date and URI
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		getQuery := req.URL.Query()
+
+		assert.Equal(t, "/v2/account/activities/DIV", req.URL.Path)
+		assert.Equal(t, "2019-01-01T00:00:00-07:00", getQuery.Get("after"))
+		assert.Equal(t, "10", getQuery.Get("page_size"))
+
+		nta := []map[string]interface{}{
+			{
+				"activity_type":    "DIV",
+				"id":               "20190801011955195::5f596936-6f23-4cef-bdf1-3806aae57dbf",
+				"date":             "2019-08-01",
+				"net_amount":       "1.02",
+				"symbol":           "T",
+				"qty":              "2",
+				"per_share_amount": "0.51",
+			},
+		}
+		return &http.Response{
+			Body: genBody(nta),
+		}, nil
+	}
+
+	afterDate := time.Date(2019, 1, 1, 0, 0, 0, 100, time.Now().Location())
+	pageSize := 10
+	req := &AccountActivitiesRequest{
+		After:    &afterDate,
+		PageSize: &pageSize,
+	}
+
+	_, err = c.GetAccountActivities(&dividendsActivityType, req)
+	assert.NoError(t, err)
 }
 
 type nopCloser struct {

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -627,7 +627,7 @@ func TestGetAccountActivities(t *testing.T) {
 		}, nil
 	}
 
-	afterDate := time.Date(2019, 1, 1, 0, 0, 0, 100, time.Now().Location())
+	afterDate := time.Date(2019, 1, 1, 0, 0, 0, 100, time.UTC)
 	pageSize := 10
 	req := &AccountActivitiesRequest{
 		After:    &afterDate,

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -608,7 +608,7 @@ func TestGetAccountActivities(t *testing.T) {
 		getQuery := req.URL.Query()
 
 		assert.Equal(t, "/v2/account/activities/DIV", req.URL.Path)
-		assert.Equal(t, "2019-01-01T00:00:00-07:00", getQuery.Get("after"))
+		assert.Equal(t, "2019-01-01T07:00:00Z", getQuery.Get("after"))
 		assert.Equal(t, "10", getQuery.Get("page_size"))
 
 		nta := []map[string]interface{}{

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -608,7 +608,7 @@ func TestGetAccountActivities(t *testing.T) {
 		getQuery := req.URL.Query()
 
 		assert.Equal(t, "/v2/account/activities/DIV", req.URL.Path)
-		assert.Equal(t, "2019-01-01T07:00:00Z", getQuery.Get("after"))
+		assert.Equal(t, "2019-01-01T07:00:00.0000001Z", getQuery.Get("after"))
 		assert.Equal(t, "10", getQuery.Get("page_size"))
 
 		nta := []map[string]interface{}{


### PR DESCRIPTION
Currently the function is using .String() for date fields which is a invalid date format of `2006-01-02 15:04:05.999999999 -0700 MST` for the API. I updated the fields to explicitly use RFC3339 which is a perfectly valid format. Tested using go1.19.1.