### PR TITLE
Add side field to ListOrdersRequest

### DIFF
--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -242,6 +242,7 @@ type ListOrdersRequest struct {
 	Direction *string    `json:"direction"`
 	Nested    *bool      `json:"nested"`
 	Symbols   *string    `json:"symbols"`
+	Side      *string    `json:"side"`
 }
 
 type Side string

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -512,6 +512,10 @@ func (c *client) ListOrdersWithRequest(req ListOrdersRequest) ([]Order, error) {
 		q.Set("symbols", *req.Symbols)
 	}
 
+	if req.Side != nil {
+		q.Set("side", *req.Side)
+	}
+
 	u.RawQuery = q.Encode()
 
 	resp, err := c.get(u)

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -183,6 +183,7 @@ func TestListOrdersWithEmptyRequest(t *testing.T) {
 		assert.Equal(t, "", req.URL.Query().Get("direction"))
 		assert.Equal(t, "", req.URL.Query().Get("nested"))
 		assert.Equal(t, "", req.URL.Query().Get("symbols"))
+		assert.Equal(t, "", req.URL.Query().Get("side"))
 
 		orders := []Order{
 			{
@@ -214,6 +215,7 @@ func TestListOrdersWithRequest(t *testing.T) {
 		assert.Equal(t, "asc", req.URL.Query().Get("direction"))
 		assert.Equal(t, "true", req.URL.Query().Get("nested"))
 		assert.Equal(t, "AAPL,TSLA", req.URL.Query().Get("symbols"))
+		assert.Equal(t, "buy", req.URL.Query().Get("side"))
 
 		orders := []Order{
 			{
@@ -232,6 +234,7 @@ func TestListOrdersWithRequest(t *testing.T) {
 	direction := "asc"
 	nested := true
 	symbols := "AAPL,TSLA"
+	side := "buy"
 
 	req := ListOrdersRequest{
 		Status:    &status,
@@ -241,6 +244,7 @@ func TestListOrdersWithRequest(t *testing.T) {
 		Direction: &direction,
 		Nested:    &nested,
 		Symbols:   &symbols,
+		Side:      &side,
 	}
 
 	orders, err := c.ListOrdersWithRequest(req)


### PR DESCRIPTION
According to the [API Doc](https://alpaca.markets/docs/api-references/trading-api/orders/#get-a-list-of-orders), there is a query parameter for `side` in the list orders endpoint.

This PR adds the field to the according entity.