### PR TITLE
feat: add watchlist endpoint implementation

### DIFF
--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -380,6 +380,6 @@ type UpdateWatchlistRequest struct {
 	Symbols []string `json:"symbols"`
 }
 
-type AddAssetToWatchlistRequest struct {
+type AddSymbolToWatchlistRequest struct {
 	Symbol string `json:"symbol"`
 }

--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -383,3 +383,7 @@ type UpdateWatchlistRequest struct {
 type AddSymbolToWatchlistRequest struct {
 	Symbol string `json:"symbol"`
 }
+
+type RemoveSymbolFromWatchlistRequest struct {
+	Symbol string `json:"symbol"`
+}

--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -360,3 +360,26 @@ type Announcement struct {
 	OldRate                 string `json:"old_rate"`
 	NewRate                 string `json:"new_rate"`
 }
+
+type Watchlist struct {
+	AccountID string  `json:"account_id"`
+	ID        string  `json:"id"`
+	CreatedAt string  `json:"created_at"`
+	UpdatedAt string  `json:"updated_at"`
+	Name      string  `json:"name"`
+	Assets    []Asset `json:"assets"`
+}
+
+type CreateWatchlistRequest struct {
+	Name    string   `json:"name"`
+	Symbols []string `json:"symbols"`
+}
+
+type UpdateWatchlistRequest struct {
+	Name    string   `json:"name"`
+	Symbols []string `json:"symbols"`
+}
+
+type AddAssetToWatchlistRequest struct {
+	Symbol string `json:"symbol"`
+}

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -40,6 +40,13 @@ type Client interface {
 	GetAsset(symbol string) (*Asset, error)
 	GetAnnouncements(req GetAnnouncementsRequest) ([]Announcement, error)
 	GetAnnouncement(announcementID string) (*Announcement, error)
+	GetWatchlists() ([]Watchlist, error)
+	CreateWatchlist(req CreateWatchlistRequest) (*Watchlist, error)
+	GetWatchlist(watchlistID string) (*Watchlist, error)
+	UpdateWatchlist(watchlistID string, req UpdateWatchlistRequest) (*Watchlist, error)
+	AddAssetToWatchlist(watchlistID string, req AddAssetToWatchlistRequest) (*Watchlist, error)
+	RemoveSymbolFromWatchlist(watchlistID string, symbol string) error
+	DeleteWatchlist(watchlistID string) error
 	StreamTradeUpdates(ctx context.Context, handler func(TradeUpdate)) error
 	StreamTradeUpdatesInBackground(ctx context.Context, handler func(TradeUpdate))
 }
@@ -772,6 +779,126 @@ func (c *client) GetAnnouncement(announcementID string) (*Announcement, error) {
 	return announcement, nil
 }
 
+func (c *client) GetWatchlists() ([]Watchlist, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/%s/watchlists", c.opts.BaseURL, apiVersion))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.get(u)
+	if err != nil {
+		return nil, err
+	}
+
+	var watchlists []Watchlist
+
+	if err = unmarshal(resp, &watchlists); err != nil {
+		return nil, err
+	}
+
+	return watchlists, nil
+}
+
+func (c *client) CreateWatchlist(req CreateWatchlistRequest) (*Watchlist, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/%s/watchlists", c.opts.BaseURL, apiVersion))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.post(u, req)
+	if err != nil {
+		return nil, err
+	}
+
+	watchlist := &Watchlist{}
+
+	if err = unmarshal(resp, watchlist); err != nil {
+		return nil, err
+	}
+
+	return watchlist, nil
+}
+
+func (c *client) GetWatchlist(watchlistID string) (*Watchlist, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/%s/watchlists/%s", c.opts.BaseURL, apiVersion, watchlistID))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.get(u)
+	if err != nil {
+		return nil, err
+	}
+
+	watchlist := &Watchlist{}
+
+	if err = unmarshal(resp, watchlist); err != nil {
+		return nil, err
+	}
+
+	return watchlist, nil
+}
+
+func (c *client) UpdateWatchlist(watchlistID string, req UpdateWatchlistRequest) (*Watchlist, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/%s/watchlists/%s", c.opts.BaseURL, apiVersion, watchlistID))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.put(u, req)
+	if err != nil {
+		return nil, err
+	}
+
+	watchlist := &Watchlist{}
+
+	if err = unmarshal(resp, watchlist); err != nil {
+		return nil, err
+	}
+
+	return watchlist, nil
+}
+
+func (c *client) AddAssetToWatchlist(watchlistID string, req AddAssetToWatchlistRequest) (*Watchlist, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/%s/watchlists/%s", c.opts.BaseURL, apiVersion, watchlistID))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.post(u, req)
+	if err != nil {
+		return nil, err
+	}
+
+	watchlist := &Watchlist{}
+
+	if err = unmarshal(resp, watchlist); err != nil {
+		return nil, err
+	}
+
+	return watchlist, nil
+}
+
+func (c *client) RemoveSymbolFromWatchlist(watchlistID string, symbol string) error {
+	u, err := url.Parse(fmt.Sprintf("%s/%s/watchlists/%s/%s", c.opts.BaseURL, apiVersion, watchlistID, symbol))
+	if err != nil {
+		return err
+	}
+
+	_, err = c.delete(u)
+	return err
+}
+
+func (c *client) DeleteWatchlist(watchlistID string) error {
+	u, err := url.Parse(fmt.Sprintf("%s/%s/watchlists/%s", c.opts.BaseURL, apiVersion, watchlistID))
+	if err != nil {
+		return err
+	}
+
+	_, err = c.delete(u)
+	return err
+}
+
 // GetAccount returns the user's account information
 // using the default Alpaca client.
 func GetAccount() (*Account, error) {
@@ -883,6 +1010,48 @@ func GetAnnouncement(announcementID string) (*Announcement, error) {
 	return DefaultClient.GetAnnouncement(announcementID)
 }
 
+// GetWatchlists returns a list of watchlists
+// with the default Alpaca client.
+func GetWatchlists() ([]Watchlist, error) {
+	return DefaultClient.GetWatchlists()
+}
+
+// CreateWatchlist creates a new watchlist
+// with the default Alpaca client.
+func CreateWatchlist(req CreateWatchlistRequest) (*Watchlist, error) {
+	return DefaultClient.CreateWatchlist(req)
+}
+
+// GetWatchlist returns a single watchlist by getting the watchlist id
+// with the default Alpaca client.
+func GetWatchlist(watchlistID string) (*Watchlist, error) {
+	return DefaultClient.GetWatchlist(watchlistID)
+}
+
+// UpdateWatchlist updates a watchlist by getting the watchlist id
+// with the default Alpaca client.
+func UpdateWatchlist(watchlistID string, req UpdateWatchlistRequest) (*Watchlist, error) {
+	return DefaultClient.UpdateWatchlist(watchlistID, req)
+}
+
+// DeleteWatchlist deletes a watchlist by getting the watchlist id
+// with the default Alpaca client.
+func DeleteWatchlist(watchlistID string) error {
+	return DefaultClient.DeleteWatchlist(watchlistID)
+}
+
+// AddAssetToWatchlist adds an asset to a watchlist by getting the watchlist id
+// with the default Alpaca client.
+func AddAssetToWatchlist(watchlistID string, req AddAssetToWatchlistRequest) (*Watchlist, error) {
+	return DefaultClient.AddAssetToWatchlist(watchlistID, req)
+}
+
+// RemoveSymbolFromWatchlist removes an asset from a watchlist by getting the watchlist id
+// with the default Alpaca client.
+func RemoveSymbolFromWatchlist(watchlistID string, symbol string) error {
+	return DefaultClient.RemoveSymbolFromWatchlist(watchlistID, symbol)
+}
+
 func (c *client) get(u *url.URL) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
@@ -899,6 +1068,20 @@ func (c *client) post(u *url.URL, data interface{}) (*http.Response, error) {
 	}
 
 	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.do(c, req)
+}
+
+func (c *client) put(u *url.URL, data interface{}) (*http.Response, error) {
+	buf, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, u.String(), bytes.NewReader(buf))
 	if err != nil {
 		return nil, err
 	}

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -44,7 +44,7 @@ type Client interface {
 	CreateWatchlist(req CreateWatchlistRequest) (*Watchlist, error)
 	GetWatchlist(watchlistID string) (*Watchlist, error)
 	UpdateWatchlist(watchlistID string, req UpdateWatchlistRequest) (*Watchlist, error)
-	AddAssetToWatchlist(watchlistID string, req AddAssetToWatchlistRequest) (*Watchlist, error)
+	AddSymbolToWatchlist(watchlistID string, req AddSymbolToWatchlistRequest) (*Watchlist, error)
 	RemoveSymbolFromWatchlist(watchlistID string, symbol string) error
 	DeleteWatchlist(watchlistID string) error
 	StreamTradeUpdates(ctx context.Context, handler func(TradeUpdate)) error
@@ -859,7 +859,7 @@ func (c *client) UpdateWatchlist(watchlistID string, req UpdateWatchlistRequest)
 	return watchlist, nil
 }
 
-func (c *client) AddAssetToWatchlist(watchlistID string, req AddAssetToWatchlistRequest) (*Watchlist, error) {
+func (c *client) AddSymbolToWatchlist(watchlistID string, req AddSymbolToWatchlistRequest) (*Watchlist, error) {
 	u, err := url.Parse(fmt.Sprintf("%s/%s/watchlists/%s", c.opts.BaseURL, apiVersion, watchlistID))
 	if err != nil {
 		return nil, err
@@ -1040,10 +1040,10 @@ func DeleteWatchlist(watchlistID string) error {
 	return DefaultClient.DeleteWatchlist(watchlistID)
 }
 
-// AddAssetToWatchlist adds an asset to a watchlist by getting the watchlist id
+// AddSymbolToWatchlist adds an asset to a watchlist by getting the watchlist id
 // with the default Alpaca client.
-func AddAssetToWatchlist(watchlistID string, req AddAssetToWatchlistRequest) (*Watchlist, error) {
-	return DefaultClient.AddAssetToWatchlist(watchlistID, req)
+func AddSymbolToWatchlist(watchlistID string, req AddSymbolToWatchlistRequest) (*Watchlist, error) {
+	return DefaultClient.AddSymbolToWatchlist(watchlistID, req)
 }
 
 // RemoveSymbolFromWatchlist removes an asset from a watchlist by getting the watchlist id

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -3,6 +3,7 @@ package alpaca
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -605,57 +606,103 @@ func TestClient_DeleteWatchlist(t *testing.T) {
 }
 
 func TestClient_AddSymbolToWatchlist(t *testing.T) {
-	c := testClient()
-	// successful
-	c.do = func(c *client, req *http.Request) (*http.Response, error) {
-		assert.Equal(t, "api.alpaca.markets", req.URL.Host)
-		assert.Equal(t, "/v2/watchlists/123", req.URL.Path)
-		assert.Equal(t, "POST", req.Method)
+	t.Run("happy path", func(t *testing.T) {
+		c := testClient()
+		// successful
+		c.do = func(c *client, req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "api.alpaca.markets", req.URL.Host)
+			assert.Equal(t, "/v2/watchlists/123", req.URL.Path)
+			assert.Equal(t, "POST", req.Method)
 
-		watchlist := Watchlist{
-			AccountID: "123",
-			ID:        "some_id",
-			Name:      "testname",
-			Assets: []Asset{
-				{
-					ID:       "some_id",
-					Name:     "AAPL",
-					Exchange: "NASDAQ",
+			watchlist := Watchlist{
+				AccountID: "123",
+				ID:        "some_id",
+				Name:      "testname",
+				Assets: []Asset{
+					{
+						ID:       "some_id",
+						Name:     "AAPL",
+						Exchange: "NASDAQ",
+					},
 				},
-			},
+			}
+
+			return &http.Response{
+				Body: genBody(watchlist),
+			}, nil
 		}
 
-		return &http.Response{
-			Body: genBody(watchlist),
-		}, nil
-	}
-
-	watchlist, err := c.AddSymbolToWatchlist("123", AddSymbolToWatchlistRequest{
-		Symbol: "AAPL",
+		watchlist, err := c.AddSymbolToWatchlist("123", AddSymbolToWatchlistRequest{
+			Symbol: "AAPL",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, watchlist)
+		require.Equal(t, "testname", watchlist.Name)
+		require.Len(t, watchlist.Assets, 1)
+		require.Equal(t, "AAPL", watchlist.Assets[0].Name)
+		require.Equal(t, "NASDAQ", watchlist.Assets[0].Exchange)
 	})
-	require.NoError(t, err)
-	require.NotNil(t, watchlist)
-	require.Equal(t, "testname", watchlist.Name)
-	require.Len(t, watchlist.Assets, 1)
-	require.Equal(t, "AAPL", watchlist.Assets[0].Name)
-	require.Equal(t, "NASDAQ", watchlist.Assets[0].Exchange)
+
+	t.Run("error: symbol not found", func(t *testing.T) {
+		c := testClient()
+		// successful
+		c.do = func(c *client, req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "api.alpaca.markets", req.URL.Host)
+			assert.Equal(t, "/v2/watchlists/123", req.URL.Path)
+			assert.Equal(t, "POST", req.Method)
+
+			return &http.Response{
+				Body:       genBody(nil),
+				StatusCode: http.StatusBadRequest,
+			}, nil
+		}
+
+		_, err := c.AddSymbolToWatchlist("123", AddSymbolToWatchlistRequest{})
+		require.Error(t, err)
+		require.Equal(t, ErrSymbolNotFound, err)
+	})
+
 }
 
 func TestClient_RemoveSymbolFromWatchlist(t *testing.T) {
-	c := testClient()
-	// successful
-	c.do = func(c *client, req *http.Request) (*http.Response, error) {
-		assert.Equal(t, "api.alpaca.markets", req.URL.Host)
-		assert.Equal(t, "/v2/watchlists/123/AAPL", req.URL.Path)
-		assert.Equal(t, "DELETE", req.Method)
+	t.Run("happy path", func(t *testing.T) {
+		c := testClient()
+		// successful
+		c.do = func(c *client, req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "api.alpaca.markets", req.URL.Host)
+			assert.Equal(t, "/v2/watchlists/123/AAPL", req.URL.Path)
+			assert.Equal(t, "DELETE", req.Method)
 
-		return &http.Response{
-			Body: genBody(nil),
-		}, nil
-	}
+			return &http.Response{
+				Body: genBody(nil),
+			}, nil
+		}
 
-	err := c.RemoveSymbolFromWatchlist("123", "AAPL")
-	require.NoError(t, err)
+		err := c.RemoveSymbolFromWatchlist("123", RemoveSymbolFromWatchlistRequest{
+			Symbol: "AAPL",
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("error: symbol is required", func(t *testing.T) {
+		c := testClient()
+		// successful
+		c.do = func(c *client, req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "api.alpaca.markets", req.URL.Host)
+			assert.Equal(t, "/v2/watchlists/123/AAPL", req.URL.Path)
+			assert.Equal(t, "DELETE", req.Method)
+
+			return &http.Response{
+				Body:       genBody(nil),
+				StatusCode: http.StatusBadRequest,
+			}, errors.New("symbol is required")
+		}
+
+		err := c.RemoveSymbolFromWatchlist("123", RemoveSymbolFromWatchlistRequest{})
+		require.Error(t, err)
+		require.Equal(t, ErrSymbolNotFound, err)
+	})
+
 }
 
 func TestCancelOrder(t *testing.T) {

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -443,6 +443,192 @@ func TestClient_GetAnnouncement(t *testing.T) {
 	require.NotNil(t, announcement)
 }
 
+func TestClient_GetWatchlists(t *testing.T) {
+	c := testClient()
+	// successful
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "api.alpaca.markets", req.URL.Host)
+		assert.Equal(t, "/v2/watchlists", req.URL.Path)
+		assert.Equal(t, "GET", req.Method)
+
+		watchlists := []Watchlist{
+			{
+				AccountID: "123",
+				ID:        "some_id",
+				Name:      "testname",
+				Assets: []Asset{
+					{
+						ID:       "some_id",
+						Name:     "AAPL",
+						Exchange: "NASDAQ",
+					},
+				},
+			},
+		}
+
+		return &http.Response{
+			Body: genBody(watchlists),
+		}, nil
+	}
+
+	watchlists, err := c.GetWatchlists()
+	require.NoError(t, err)
+	require.Len(t, watchlists, 1)
+}
+
+func TestClient_CreateWatchlist(t *testing.T) {
+	c := testClient()
+	// successful
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "api.alpaca.markets", req.URL.Host)
+		assert.Equal(t, "/v2/watchlists", req.URL.Path)
+		assert.Equal(t, "POST", req.Method)
+
+		watchlist := Watchlist{
+			AccountID: "123",
+			ID:        "some_id",
+			Name:      "testname",
+			Assets: []Asset{
+				{
+					ID:       "some_id",
+					Name:     "AAPL",
+					Exchange: "NASDAQ",
+				},
+			},
+		}
+
+		return &http.Response{
+			Body: genBody(watchlist),
+		}, nil
+	}
+
+	watchlist, err := c.CreateWatchlist(CreateWatchlistRequest{
+		Name:    "testname",
+		Symbols: []string{"AAPL"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, watchlist)
+}
+
+func TestClient_GetWatchlist(t *testing.T) {
+	c := testClient()
+	// successful
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "api.alpaca.markets", req.URL.Host)
+		assert.Equal(t, "/v2/watchlists/123", req.URL.Path)
+		assert.Equal(t, "GET", req.Method)
+
+		watchlist := Watchlist{
+			AccountID: "123",
+			ID:        "some_id",
+			Name:      "testname",
+			Assets: []Asset{
+				{
+					ID:       "some_id",
+					Name:     "AAPL",
+					Exchange: "NASDAQ",
+				},
+			},
+		}
+
+		return &http.Response{
+			Body: genBody(watchlist),
+		}, nil
+	}
+
+	watchlist, err := c.GetWatchlist("123")
+	require.NoError(t, err)
+	require.NotNil(t, watchlist)
+}
+
+func TestClient_UpdateWatchlist(t *testing.T) {
+	c := testClient()
+	// successful
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "api.alpaca.markets", req.URL.Host)
+		assert.Equal(t, "/v2/watchlists/123", req.URL.Path)
+		assert.Equal(t, "PUT", req.Method)
+
+		watchlist := Watchlist{
+			AccountID: "123",
+			ID:        "some_id",
+			Name:      "testname",
+			Assets: []Asset{
+				{
+					ID:       "some_id",
+					Name:     "AAPL",
+					Exchange: "NASDAQ",
+				},
+			},
+		}
+
+		return &http.Response{
+			Body: genBody(watchlist),
+		}, nil
+	}
+
+	watchlist, err := c.UpdateWatchlist("123", UpdateWatchlistRequest{
+		Name:    "testname",
+		Symbols: []string{"AAPL"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, watchlist)
+}
+
+func TestClient_DeleteWatchlist(t *testing.T) {
+	c := testClient()
+	// successful
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "api.alpaca.markets", req.URL.Host)
+		assert.Equal(t, "/v2/watchlists/123", req.URL.Path)
+		assert.Equal(t, "DELETE", req.Method)
+
+		return &http.Response{
+			Body: genBody(nil),
+		}, nil
+	}
+
+	err := c.DeleteWatchlist("123")
+	require.NoError(t, err)
+}
+
+func TestClient_AddToWatchlist(t *testing.T) {
+	c := testClient()
+	// successful
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "api.alpaca.markets", req.URL.Host)
+		assert.Equal(t, "/v2/watchlists/123", req.URL.Path)
+		assert.Equal(t, "POST", req.Method)
+
+		return &http.Response{
+			Body: genBody(nil),
+		}, nil
+	}
+
+	watchlist, err := c.AddAssetToWatchlist("123", AddAssetToWatchlistRequest{
+		Symbol: "AAPL",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, watchlist)
+}
+
+func TestClient_RemoveSymbolFromWatchlist(t *testing.T) {
+	c := testClient()
+	// successful
+	c.do = func(c *client, req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "api.alpaca.markets", req.URL.Host)
+		assert.Equal(t, "/v2/watchlists/123/AAPL", req.URL.Path)
+		assert.Equal(t, "DELETE", req.Method)
+
+		return &http.Response{
+			Body: genBody(nil),
+		}, nil
+	}
+
+	err := c.RemoveSymbolFromWatchlist("123", "AAPL")
+	require.NoError(t, err)
+}
+
 func TestCancelOrder(t *testing.T) {
 	c := testClient()
 	// successful

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -508,6 +508,10 @@ func TestClient_CreateWatchlist(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, watchlist)
+	require.Equal(t, "testname", watchlist.Name)
+	require.Len(t, watchlist.Assets, 1)
+	require.Equal(t, "AAPL", watchlist.Assets[0].Name)
+	require.Equal(t, "NASDAQ", watchlist.Assets[0].Exchange)
 }
 
 func TestClient_GetWatchlist(t *testing.T) {
@@ -539,6 +543,10 @@ func TestClient_GetWatchlist(t *testing.T) {
 	watchlist, err := c.GetWatchlist("123")
 	require.NoError(t, err)
 	require.NotNil(t, watchlist)
+	require.Equal(t, "testname", watchlist.Name)
+	require.Len(t, watchlist.Assets, 1)
+	require.Equal(t, "AAPL", watchlist.Assets[0].Name)
+	require.Equal(t, "NASDAQ", watchlist.Assets[0].Exchange)
 }
 
 func TestClient_UpdateWatchlist(t *testing.T) {
@@ -573,6 +581,10 @@ func TestClient_UpdateWatchlist(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, watchlist)
+	require.Equal(t, "testname", watchlist.Name)
+	require.Len(t, watchlist.Assets, 1)
+	require.Equal(t, "AAPL", watchlist.Assets[0].Name)
+	require.Equal(t, "NASDAQ", watchlist.Assets[0].Exchange)
 }
 
 func TestClient_DeleteWatchlist(t *testing.T) {
@@ -592,7 +604,7 @@ func TestClient_DeleteWatchlist(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestClient_AddToWatchlist(t *testing.T) {
+func TestClient_AddSymbolToWatchlist(t *testing.T) {
 	c := testClient()
 	// successful
 	c.do = func(c *client, req *http.Request) (*http.Response, error) {
@@ -600,16 +612,33 @@ func TestClient_AddToWatchlist(t *testing.T) {
 		assert.Equal(t, "/v2/watchlists/123", req.URL.Path)
 		assert.Equal(t, "POST", req.Method)
 
+		watchlist := Watchlist{
+			AccountID: "123",
+			ID:        "some_id",
+			Name:      "testname",
+			Assets: []Asset{
+				{
+					ID:       "some_id",
+					Name:     "AAPL",
+					Exchange: "NASDAQ",
+				},
+			},
+		}
+
 		return &http.Response{
-			Body: genBody(nil),
+			Body: genBody(watchlist),
 		}, nil
 	}
 
-	watchlist, err := c.AddAssetToWatchlist("123", AddAssetToWatchlistRequest{
+	watchlist, err := c.AddSymbolToWatchlist("123", AddSymbolToWatchlistRequest{
 		Symbol: "AAPL",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, watchlist)
+	require.Equal(t, "testname", watchlist.Name)
+	require.Len(t, watchlist.Assets, 1)
+	require.Equal(t, "AAPL", watchlist.Assets[0].Name)
+	require.Equal(t, "NASDAQ", watchlist.Assets[0].Exchange)
 }
 
 func TestClient_RemoveSymbolFromWatchlist(t *testing.T) {


### PR DESCRIPTION
Alpaca Documentation - https://alpaca.markets/docs/api-references/trading-api/watchlist/

Endpoints Added:
- GET - `/v2/watchlists` - Get all watchlists
- GET - `/v2/watchlists/{watchlist_id}` - Get a watchlist by id
- POST - `/v2/watchlists` - Create Watchlist
- POST - `/v2/watchlists/{watchlist_id}` - Add asset to watchlist
- PUT - `/v2/watchlists/{watchlist_id}` - Update watchlist by id
- DELETE - `/v2/watchlists/{watchlist_id}` - Delete a watchlist by id
- DELETE - `/v2/watchlists/{watchlist_id}/{symbol}` - Remove a symbol from watchlist