### PR TITLE
fix: Remove sub changes request when timeout happens

### DIFF
--- a/marketdata/stream/client_test.go
+++ b/marketdata/stream/client_test.go
@@ -659,18 +659,8 @@ func TestSubscriptionTwiceAcrossConnectionIssues(t *testing.T) {
 	// server accepts subscription
 	conn1.readCh <- serializeToMsgpack(t, []subWithT{
 		{
-			Type:         "subscription",
-			Trades:       trades1,
-			Quotes:       nil,
-			Bars:         nil,
-			UpdatedBars:  nil,
-			DailyBars:    nil,
-			Statuses:     nil,
-			LULDs:        nil,
-			CancelErrors: nil,
-			Corrections:  nil,
-			Orderbooks:   nil,
-			News:         nil,
+			Type:   "subscription",
+			Trades: trades1,
 		},
 	})
 	err = <-subRes

--- a/marketdata/stream/client_test.go
+++ b/marketdata/stream/client_test.go
@@ -693,7 +693,6 @@ func TestSubscriptionTwiceAcrossConnectionIssues(t *testing.T) {
 	// establish 2nd connection
 	conn2 := newMockConn()
 	writeInitialFlowMessagesToConn(t, conn2, subscriptions{trades: trades1})
-	// writeInitialFlowMessagesToConn(t, conn2, subscriptions{})
 	c.connCreator = func(ctx context.Context, u url.URL) (conn, error) {
 		return conn2, nil
 	}

--- a/marketdata/stream/subscription.go
+++ b/marketdata/stream/subscription.go
@@ -264,11 +264,11 @@ func (c *client) handleSubChange(subscribe bool, changes subscriptions) error {
 		c.pendingSubChange = nil
 		// Drain the c.subChanges channel to avoid waiting size 1 channel when connection is lost.
 		// Please consider using connect/disconnect callbacks to avoid requesting sub change during disconnection.
-		select {
-		case <-c.subChanges:
-			c.logger.Warnf("datav2stream: removed sub changes request due to timeout")
-		default:
-		}
+		// select {
+		// case <-c.subChanges:
+		// 	c.logger.Warnf("datav2stream: removed sub changes request due to timeout")
+		// default:
+		// }
 	}
 
 	return ErrSubscriptionChangeTimeout

--- a/marketdata/stream/subscription.go
+++ b/marketdata/stream/subscription.go
@@ -264,11 +264,11 @@ func (c *client) handleSubChange(subscribe bool, changes subscriptions) error {
 		c.pendingSubChange = nil
 		// Drain the c.subChanges channel to avoid waiting size 1 channel when connection is lost.
 		// Please consider using connect/disconnect callbacks to avoid requesting sub change during disconnection.
-		// select {
-		// case <-c.subChanges:
-		// 	c.logger.Warnf("datav2stream: removed sub changes request due to timeout")
-		// default:
-		// }
+		select {
+		case <-c.subChanges:
+			c.logger.Warnf("datav2stream: removed sub changes request due to timeout")
+		default:
+		}
 	}
 
 	return ErrSubscriptionChangeTimeout


### PR DESCRIPTION
Context:
- putting a request message into `c.subChanges` blocks process with having `c.pendingSubChangeMutex.Lock()` when subscribe request is called twice during disconnection
- this leads deadlock to wait `c.pendingSubChangeMutex.Lock()` in `connWriter()` when reconnecting

Changes:
- drain `c.subChanges` channel when timeout happens. expecting this happens only when disconnected as c.subChanges are consumed before the timeout by `connWriter()` if connected.