### PR TITLE
Add missing AccountActivity and GetAccountActivitiesRequest fields

### DIFF
--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -186,6 +186,9 @@ type AccountActivity struct {
 	NetAmount       decimal.Decimal `json:"net_amount"`
 	Description     string          `json:"description"`
 	PerShareAmount  decimal.Decimal `json:"per_share_amount"`
+	OrderID         string          `json:"order_id"`
+	OrderStatus     string          `json:"order_status"`
+	Status          string          `json:"status"`
 }
 
 //easyjson:json

--- a/alpaca/entities_easyjson.go
+++ b/alpaca/entities_easyjson.go
@@ -3017,6 +3017,12 @@ func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca23(in *jlexe
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.PerShareAmount).UnmarshalJSON(data))
 			}
+		case "order_id":
+			out.OrderID = string(in.String())
+		case "order_status":
+			out.OrderStatus = string(in.String())
+		case "status":
+			out.Status = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -3100,6 +3106,21 @@ func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca23(out *jwri
 		const prefix string = ",\"per_share_amount\":"
 		out.RawString(prefix)
 		out.Raw((in.PerShareAmount).MarshalJSON())
+	}
+	{
+		const prefix string = ",\"order_id\":"
+		out.RawString(prefix)
+		out.String(string(in.OrderID))
+	}
+	{
+		const prefix string = ",\"order_status\":"
+		out.RawString(prefix)
+		out.String(string(in.OrderStatus))
+	}
+	{
+		const prefix string = ",\"status\":"
+		out.RawString(prefix)
+		out.String(string(in.Status))
 	}
 	out.RawByte('}')
 }

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -187,6 +187,8 @@ type GetAccountActivitiesRequest struct {
 	After         time.Time `json:"after"`
 	Direction     string    `json:"direction"`
 	PageSize      int       `json:"page_size"`
+	PageToken     string    `json:"page_token"`
+	Category      string    `json:"category"`
 }
 
 // GetAccountActivities returns the account activities.
@@ -214,6 +216,12 @@ func (c *Client) GetAccountActivities(req GetAccountActivitiesRequest) ([]Accoun
 	}
 	if req.PageSize != 0 {
 		q.Set("page_size", strconv.Itoa(req.PageSize))
+	}
+	if req.PageToken != "" {
+		q.Set("page_token", req.PageToken)
+	}
+	if req.Category != "" {
+		q.Set("category", req.Category)
 	}
 	u.RawQuery = q.Encode()
 


### PR DESCRIPTION
GetAccountActivitiesRequest:
- PageToken
- Category

AccountActivity:
- OrderID and OrderStatus (for FILL activities only) [are documented](https://docs.alpaca.markets/reference/getaccountactivities-2)
- Status (for non-FILL activities) is not documented