### PR TITLE
Add logging and optional callback to buffer fills

### DIFF
--- a/marketdata/stream/client_test.go
+++ b/marketdata/stream/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
 
 	"github.com/alpacahq/alpaca-trade-api-go/v3/marketdata"
 )
@@ -839,6 +840,90 @@ func TestSubscribeFailsDueToError(t *testing.T) {
 	err = <-subRes
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrSubscriptionChangeInvalidForFeed))
+}
+
+func assertBufferFills(t *testing.T, bufferFills, trades chan Trade, minID, maxID, minTrades int) {
+	timer := time.NewTimer(100 * time.Millisecond)
+	count := maxID - minID + 1
+	minFills := count - minTrades - 1
+
+	sumTrades := 0
+	sumFills := 0
+	for i := 0; i < minFills; i++ {
+		select {
+		case trade := <-bufferFills:
+			sumFills++
+			assert.LessOrEqual(t, int64(minID), trade.ID)
+			assert.GreaterOrEqual(t, int64(maxID), trade.ID)
+		case <-timer.C:
+			require.Fail(t, "buffer fill timeout")
+		}
+	}
+
+	for i := minFills; i < count; i++ {
+		select {
+		case trade := <-bufferFills:
+			sumFills++
+			assert.LessOrEqual(t, int64(minID), trade.ID)
+			assert.GreaterOrEqual(t, int64(maxID), trade.ID)
+		case trade := <-trades:
+			sumTrades++
+			assert.LessOrEqual(t, int64(minID), trade.ID)
+			assert.GreaterOrEqual(t, int64(maxID), trade.ID)
+		}
+	}
+
+	assert.LessOrEqual(t, minFills, sumFills)
+	assert.LessOrEqual(t, minTrades, sumTrades)
+}
+
+func TestCallbacksCalledOnBufferFill(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	connection := newMockConn()
+	defer connection.close()
+
+	writeInitialFlowMessagesToConn(t, connection, subscriptions{trades: []string{"ALPACA"}})
+
+	const bufferSize = 2
+	bufferFills := make(chan Trade, 10)
+	trades := make(chan Trade)
+
+	c := NewStocksClient(marketdata.IEX,
+		WithBufferSize(bufferSize),
+		WithBufferFillCallback(func(msg []byte) {
+			trades := []tradeWithT{}
+			if err := msgpack.Unmarshal(msg, &trades); err != nil {
+				require.Fail(t, "msgpack unmarshal error")
+			}
+			bufferFills <- Trade{
+				ID:     trades[0].ID,
+				Symbol: trades[0].Symbol,
+			}
+		}),
+		withConnCreator(func(ctx context.Context, u url.URL) (conn, error) { return connection, nil }),
+		WithTrades(func(t Trade) { trades <- t }, "ALPACA"),
+	)
+	require.NoError(t, c.Connect(ctx))
+
+	// The buffer size is 2 but we send at least 4 (2 buffer size, 1
+	// messageProcessor goroutine, 1 extra) trades to have a buffer fill. The
+	// messageProcessor goroutines can read c.in while the rest of messages can
+	// be queued in the buffered channel.
+	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 1}})
+	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 2}})
+	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 3}})
+	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 4}})
+	assertBufferFills(t, bufferFills, trades, 1, 4, bufferSize)
+
+	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 5}})
+	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 6}})
+	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 7}})
+	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 8}})
+	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 9}})
+	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 10}})
+	assertBufferFills(t, bufferFills, trades, 5, 10, bufferSize)
 }
 
 func TestPingFails(t *testing.T) {

--- a/marketdata/stream/client_test.go
+++ b/marketdata/stream/client_test.go
@@ -894,9 +894,7 @@ func TestCallbacksCalledOnBufferFill(t *testing.T) {
 		WithBufferSize(bufferSize),
 		WithBufferFillCallback(func(msg []byte) {
 			trades := []tradeWithT{}
-			if err := msgpack.Unmarshal(msg, &trades); err != nil {
-				require.Fail(t, "msgpack unmarshal error")
-			}
+			require.NoError(t, msgpack.Unmarshal(msg, &trades))
 			bufferFills <- Trade{
 				ID:     trades[0].ID,
 				Symbol: trades[0].Symbol,
@@ -911,18 +909,14 @@ func TestCallbacksCalledOnBufferFill(t *testing.T) {
 	// messageProcessor goroutine, 1 extra) trades to have a buffer fill. The
 	// messageProcessor goroutines can read c.in while the rest of messages can
 	// be queued in the buffered channel.
-	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 1}})
-	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 2}})
-	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 3}})
-	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 4}})
+	for id := int64(1); id <= 4; id++ {
+		connection.readCh <- serializeToMsgpack(t, []any{tradeWithT{Type: "t", Symbol: "ALPACA", ID: id}})
+	}
 	assertBufferFills(t, bufferFills, trades, 1, 4, bufferSize)
 
-	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 5}})
-	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 6}})
-	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 7}})
-	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 8}})
-	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 9}})
-	connection.readCh <- serializeToMsgpack(t, []interface{}{tradeWithT{Type: "t", Symbol: "ALPACA", ID: 10}})
+	for id := int64(5); id <= 10; id++ {
+		connection.readCh <- serializeToMsgpack(t, []any{tradeWithT{Type: "t", Symbol: "ALPACA", ID: id}})
+	}
 	assertBufferFills(t, bufferFills, trades, 5, 10, bufferSize)
 }
 

--- a/marketdata/stream/conn_test.go
+++ b/marketdata/stream/conn_test.go
@@ -6,8 +6,10 @@ import (
 	"sync"
 )
 
-var errClose = errors.New("closed")
-var errPingDisabled = errors.New("ping disabled")
+var (
+	errClose        = errors.New("closed")
+	errPingDisabled = errors.New("ping disabled")
+)
 
 type mockConn struct {
 	pingCh       chan struct{}

--- a/marketdata/stream/options.go
+++ b/marketdata/stream/options.go
@@ -41,6 +41,7 @@ type options struct {
 	reconnectLimit     int
 	reconnectDelay     time.Duration
 	connectCallback    func()
+	bufferFillCallback func([]byte)
 	disconnectCallback func()
 	processorCount     int
 	bufferSize         int
@@ -120,6 +121,17 @@ func WithReconnectSettings(limit int, delay time.Duration) Option {
 func WithConnectCallback(callback func()) Option {
 	return newFuncOption(func(o *options) {
 		o.connectCallback = callback
+	})
+}
+
+// WithBufferFillCallback runs the callback function whenever the buffer is full
+// and msg cannot be delivered. This usually happens when trade/quote handlers
+// process the messages slowly and it cannot keep up with the pace how messages
+// are received. This callback should run fast, so avoid any blocking
+// instructions in the callback.
+func WithBufferFillCallback(callback func(msg []byte)) Option {
+	return newFuncOption(func(o *options) {
+		o.bufferFillCallback = callback
 	})
 }
 

--- a/marketdata/stream/options.go
+++ b/marketdata/stream/options.go
@@ -126,7 +126,7 @@ func WithConnectCallback(callback func()) Option {
 
 // WithBufferFillCallback runs the callback function whenever the buffer is full
 // and msg cannot be delivered. This usually happens when trade/quote handlers
-// process the messages slowly and it cannot keep up with the pace how messages
+// process the messages slowly and they cannot keep up with the pace how messages
 // are received. This callback should run fast, so avoid any blocking
 // instructions in the callback.
 func WithBufferFillCallback(callback func(msg []byte)) Option {


### PR DESCRIPTION
Slow client related issues:
* `client.maintainConnection` waits for the `messageProcessor` goroutine(s) to finish to reconnect: this delays the reconnect and more messages can be missed
* whenever the client buffer `c.in` is full the `connReader` goroutine is blocked: the TCP stack of the operating system will buffer the messages and can cause disconnects if the application gets the pong message late, moreover the `connReader` goroutine will not exit if the context is cancelled while it is blocked on writing to `c.in`