### PR TITLE
Make PositionIntent optional in PlaceOrderRequest

### DIFF
--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -558,7 +558,7 @@ type PlaceOrderRequest struct {
 	StopLoss       *StopLoss        `json:"stop_loss"`
 	TrailPrice     *decimal.Decimal `json:"trail_price"`
 	TrailPercent   *decimal.Decimal `json:"trail_percent"`
-	PositionIntent *PositionIntent  `json:"position_intent"`
+	PositionIntent PositionIntent   `json:"position_intent,omitempty"`
 	Legs           []Leg            `json:"legs"` // mleg order legs
 }
 

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -558,7 +558,7 @@ type PlaceOrderRequest struct {
 	StopLoss       *StopLoss        `json:"stop_loss"`
 	TrailPrice     *decimal.Decimal `json:"trail_price"`
 	TrailPercent   *decimal.Decimal `json:"trail_percent"`
-	PositionIntent PositionIntent   `json:"position_intent"`
+	PositionIntent *PositionIntent  `json:"position_intent"`
 	Legs           []Leg            `json:"legs"` // mleg order legs
 }
 


### PR DESCRIPTION
The field `PositionIntent` was introduced in https://github.com/alpacahq/alpaca-trade-api-go/pull/294 as mandatory field, should've been optional 

Fixes https://github.com/alpacahq/alpaca-trade-api-go/issues/327