### PR TITLE
Replace regex with strings.Contains in isHTTP4xx

### DIFF
--- a/marketdata/stream/client.go
+++ b/marketdata/stream/client.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -542,11 +542,12 @@ func isErrorIrrecoverableAtInit(err error) bool {
 }
 
 func isHTTP4xx(err error) bool {
-	// Unfortunately the coder/websocket error is a simple formatted string, created by fmt.Errorf,
+	// Unfortunately, the coder/websocket error is a simple formatted string, created by fmt.Errorf,
 	// so the only check we can do is string matching
-	pattern := `expected handshake response status code 101 but got 4\d\d`
-	ok, _ := regexp.MatchString(pattern, err.Error())
-	return ok
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "expected handshake response status code 101 but got 4")
 }
 
 func wrapIrrecoverable(err error) error {


### PR DESCRIPTION
Ran the test on my local machine Apple M3 Pro, 36 GB Ram 

The string-based approach (is_http_4xx_string) is significantly faster than the regex-based approach (is_http_4xx_regex).
	•	Regex approach: ~0.1275 seconds (for 100,000 executions)
	•	String matching approach: ~0.0334 seconds (for 100,000 executions)

The string-matching method is about 3.8x faster than the regex approach. 