### PR TITLE
Fix: Ensure proper closure of HTTP response body to prevent resource leak

### DIFF
--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -362,6 +362,11 @@ type APIError struct {
 }
 
 func APIErrorFromResponse(resp *http.Response) error {
+	if resp == nil {
+		return fmt.Errorf("response is nil")
+	}
+	defer resp.Body.Close()
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -1342,6 +1342,10 @@ func unmarshal(resp *http.Response, v easyjson.Unmarshaler) error {
 }
 
 func closeResp(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return // Avoids panic if resp is nil
+	}
+
 	// The underlying TCP connection can not be reused if the body is not fully read
 	_, _ = io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()


### PR DESCRIPTION
This PR fixes a potential resource leak issue in  code. This oversight could lead to resource exhaustion over time. ([Reference](https://stackoverflow.com/a/33238755/2949645))

Changes:

- Explicitly added `resp.Body.Close()` in all relevant places where HTTP requests are made.
- Ensures that resources are properly released after the response is handled.
- Added few nil check to avoid nil potential dereference panics. 

## Testing. 
I executed all test cases in following files. 
```
marketdata/rest_test.go
marketdata/options_test.go

alpaca/rest_test.go
alpaca/stream_test.go
alpaca/trading_test.go
```