### PR TITLE
Fix untilClose to be 15 min before market close

### DIFF
--- a/examples/mean-reversion/mean-reversion.go
+++ b/examples/mean-reversion/mean-reversion.go
@@ -133,7 +133,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to get clock: %v", err)
 		}
-		untilClose := clock.NextClose.Sub(clock.Timestamp.Add(-15 * time.Minute))
+		untilClose := clock.NextClose.Sub(clock.Timestamp) - 15*time.Minute
 		time.Sleep(untilClose)
 
 		fmt.Println("Market closing soon. Closing position.")


### PR DESCRIPTION
Fix untilClose to be 15 min before market close for mean reversion example