### PR TITLE
CRYP-894: Integrate Kraken Market Data

### DIFF
--- a/marketdata/entities.go
+++ b/marketdata/entities.go
@@ -41,7 +41,7 @@ const (
 	// US is the crypto feed for the United States.
 	US     CryptoFeed = "us"
 	GLOBAL CryptoFeed = "global"
-	KRAKEN CryptoFeed = "krakrn"
+	KRAKEN CryptoFeed = "kraken"
 )
 
 // OptionFeed defines the source feed of option data.

--- a/marketdata/entities.go
+++ b/marketdata/entities.go
@@ -41,6 +41,7 @@ const (
 	// US is the crypto feed for the United States.
 	US     CryptoFeed = "us"
 	GLOBAL CryptoFeed = "global"
+	KRAKEN CryptoFeed = "krakrn"
 )
 
 // OptionFeed defines the source feed of option data.


### PR DESCRIPTION
**Context**
With the Kraken integration as an external crypto venue, Kraken market data should be served through Alpaca Market Data APIs.

**Changes**
- Added new crypto feed - `kraken`

**Additional Considerations**
- Did not add examples for new exchange