### PR TITLE
Fix marketdata trades example

### DIFF
--- a/examples/marketdata/marketdata.go
+++ b/examples/marketdata/marketdata.go
@@ -19,7 +19,6 @@ import (
 
 // Get AAPL and MSFT trades from the tenth of a second of the 2021-08-09 market open
 func trades() {
-	marketdata.GetTrades("AAPL", marketdata.GetTradesRequest{})
 	multiTrades, err := marketdata.GetMultiTrades([]string{"AAPL", "MSFT"}, marketdata.GetTradesRequest{
 		Start: time.Date(2021, 8, 9, 13, 30, 0, 0, time.UTC),
 		End:   time.Date(2021, 8, 9, 13, 30, 0, 10000000, time.UTC),


### PR DESCRIPTION
The marketdata trades example queries the trades endpoint 2 times. The first query is exhaustive and does not return in time, so for demonstration purposes, we only keep the second.