### PR TITLE
Add support for DMA, TWAP, VWAP orders and advanced instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ The SDK supports Alpaca's Elite Smart Router with advanced order instructions fo
 Direct Market Access (DMA), Time-Weighted Average Price (TWAP), and Volume-Weighted
 Average Price (VWAP) order execution strategies.
 
-> **Note:** These features are only available to users who have enabled the [Elite Smart Router](https://alpaca.markets/elite).
+> [!NOTE]
+> These features are only available to users who have enabled the [Elite Smart Router](https://alpaca.markets/elite).
 > For more information on Alpaca Elite, see the [terms and conditions](https://files.alpaca.markets/disclosures/library/Alpaca+Elite+Agreement.pdf)
 > and the [Elite Smart Router documentation](https://docs.alpaca.markets/docs/alpaca-elite-smart-router).
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,68 @@ log.Println("order sent")
 select {}
 ```
 
+### Advanced Order Instructions (DMA, TWAP, VWAP)
+
+The SDK supports Alpaca's Elite Smart Router with advanced order instructions for
+Direct Market Access (DMA), Time-Weighted Average Price (TWAP), and Volume-Weighted
+Average Price (VWAP) order execution strategies.
+
+```go
+// DMA order - route directly to NYSE with iceberg display quantity
+displayQty := decimal.NewFromInt(100)
+qty := decimal.NewFromInt(500)
+limitPrice := decimal.NewFromFloat(150.50)
+order, err := client.PlaceOrder(alpaca.PlaceOrderRequest{
+	Symbol:      "AAPL",
+	Qty:         &qty,
+	Side:        alpaca.Buy,
+	Type:        alpaca.Limit,
+	TimeInForce: alpaca.Day,
+	LimitPrice:  &limitPrice,
+	AdvancedInstructions: &alpaca.AdvancedInstructions{
+		Algorithm:   alpaca.AlgorithmDMA,
+		Destination: alpaca.DestinationNYSE,
+		DisplayQty:  &displayQty, // Iceberg: show only 100 shares at a time
+	},
+})
+
+// TWAP order - execute evenly over a time period
+startTime := time.Date(2025, 7, 21, 9, 30, 0, 0, time.FixedZone("EST", -5*3600))
+endTime := time.Date(2025, 7, 21, 15, 30, 0, 0, time.FixedZone("EST", -5*3600))
+maxPct := decimal.NewFromFloat(0.25)
+qty := decimal.NewFromInt(10000)
+order, err := client.PlaceOrder(alpaca.PlaceOrderRequest{
+	Symbol:      "AAPL",
+	Qty:         &qty,
+	Side:        alpaca.Buy,
+	Type:        alpaca.Market,
+	TimeInForce: alpaca.Day,
+	AdvancedInstructions: &alpaca.AdvancedInstructions{
+		Algorithm:     alpaca.AlgorithmTWAP,
+		StartTime:     &startTime,
+		EndTime:       &endTime,
+		MaxPercentage: &maxPct, // Max 25% of period volume
+	},
+})
+
+// VWAP order - execute in proportion to market volume
+order, err := client.PlaceOrder(alpaca.PlaceOrderRequest{
+	Symbol:      "SPY",
+	Qty:         &qty,
+	Side:        alpaca.Sell,
+	Type:        alpaca.Market,
+	TimeInForce: alpaca.Day,
+	AdvancedInstructions: &alpaca.AdvancedInstructions{
+		Algorithm:     alpaca.AlgorithmVWAP,
+		StartTime:     &startTime,
+		EndTime:       &endTime,
+		MaxPercentage: &maxPct,
+	},
+})
+```
+
+For more details, see the [Elite Smart Router documentation](https://docs.alpaca.markets/docs/alpaca-elite-smart-router).
+
 ### Further examples
 
 See the [examples](https://github.com/alpacahq/alpaca-trade-api-go/tree/master/examples)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The SDK supports Alpaca's Elite Smart Router with advanced order instructions fo
 Direct Market Access (DMA), Time-Weighted Average Price (TWAP), and Volume-Weighted
 Average Price (VWAP) order execution strategies.
 
+> **Note:** These features are only available to users who have enabled the [Elite Smart Router](https://alpaca.markets/elite).
+> For more information on Alpaca Elite, see the [terms and conditions](https://files.alpaca.markets/disclosures/library/Alpaca+Elite+Agreement.pdf)
+> and the [Elite Smart Router documentation](https://docs.alpaca.markets/docs/alpaca-elite-smart-router).
+
 ```go
 // DMA order - route directly to NYSE with iceberg display quantity
 displayQty := decimal.NewFromInt(100)

--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -279,6 +279,8 @@ const (
 // AdvancedInstructions contains advanced routing instructions for Elite Smart Router orders.
 // These instructions enable DMA (Direct Market Access), TWAP (Time-Weighted Average Price),
 // and VWAP (Volume-Weighted Average Price) order execution strategies.
+//
+//easyjson:json
 type AdvancedInstructions struct {
 	// Algorithm specifies the advanced routing algorithm to use (DMA, TWAP, or VWAP).
 	Algorithm Algorithm `json:"algorithm,omitempty"`

--- a/alpaca/entities.go
+++ b/alpaca/entities.go
@@ -54,39 +54,40 @@ type Account struct {
 }
 
 type Order struct {
-	ID             string           `json:"id"`
-	ClientOrderID  string           `json:"client_order_id"`
-	CreatedAt      time.Time        `json:"created_at"`
-	UpdatedAt      time.Time        `json:"updated_at"`
-	SubmittedAt    time.Time        `json:"submitted_at"`
-	FilledAt       *time.Time       `json:"filled_at"`
-	ExpiredAt      *time.Time       `json:"expired_at"`
-	CanceledAt     *time.Time       `json:"canceled_at"`
-	FailedAt       *time.Time       `json:"failed_at"`
-	ReplacedAt     *time.Time       `json:"replaced_at"`
-	ReplacedBy     *string          `json:"replaced_by"`
-	Replaces       *string          `json:"replaces"`
-	AssetID        string           `json:"asset_id"`
-	Symbol         string           `json:"symbol"`
-	AssetClass     AssetClass       `json:"asset_class"`
-	OrderClass     OrderClass       `json:"order_class"`
-	Type           OrderType        `json:"type"`
-	Side           Side             `json:"side"`
-	PositionIntent PositionIntent   `json:"position_intent"`
-	TimeInForce    TimeInForce      `json:"time_in_force"`
-	Status         string           `json:"status"`
-	Notional       *decimal.Decimal `json:"notional"`
-	Qty            *decimal.Decimal `json:"qty"`
-	FilledQty      decimal.Decimal  `json:"filled_qty"`
-	FilledAvgPrice *decimal.Decimal `json:"filled_avg_price"`
-	LimitPrice     *decimal.Decimal `json:"limit_price"`
-	StopPrice      *decimal.Decimal `json:"stop_price"`
-	TrailPrice     *decimal.Decimal `json:"trail_price"`
-	TrailPercent   *decimal.Decimal `json:"trail_percent"`
-	HWM            *decimal.Decimal `json:"hwm"`
-	ExtendedHours  bool             `json:"extended_hours"`
-	RatioQty       *decimal.Decimal `json:"ratio_qty"`
-	Legs           []Order          `json:"legs"`
+	ID                   string                `json:"id"`
+	ClientOrderID        string                `json:"client_order_id"`
+	CreatedAt            time.Time             `json:"created_at"`
+	UpdatedAt            time.Time             `json:"updated_at"`
+	SubmittedAt          time.Time             `json:"submitted_at"`
+	FilledAt             *time.Time            `json:"filled_at"`
+	ExpiredAt            *time.Time            `json:"expired_at"`
+	CanceledAt           *time.Time            `json:"canceled_at"`
+	FailedAt             *time.Time            `json:"failed_at"`
+	ReplacedAt           *time.Time            `json:"replaced_at"`
+	ReplacedBy           *string               `json:"replaced_by"`
+	Replaces             *string               `json:"replaces"`
+	AssetID              string                `json:"asset_id"`
+	Symbol               string                `json:"symbol"`
+	AssetClass           AssetClass            `json:"asset_class"`
+	OrderClass           OrderClass            `json:"order_class"`
+	Type                 OrderType             `json:"type"`
+	Side                 Side                  `json:"side"`
+	PositionIntent       PositionIntent        `json:"position_intent"`
+	TimeInForce          TimeInForce           `json:"time_in_force"`
+	Status               string                `json:"status"`
+	Notional             *decimal.Decimal      `json:"notional"`
+	Qty                  *decimal.Decimal      `json:"qty"`
+	FilledQty            decimal.Decimal       `json:"filled_qty"`
+	FilledAvgPrice       *decimal.Decimal      `json:"filled_avg_price"`
+	LimitPrice           *decimal.Decimal      `json:"limit_price"`
+	StopPrice            *decimal.Decimal      `json:"stop_price"`
+	TrailPrice           *decimal.Decimal      `json:"trail_price"`
+	TrailPercent         *decimal.Decimal      `json:"trail_percent"`
+	HWM                  *decimal.Decimal      `json:"hwm"`
+	ExtendedHours        bool                  `json:"extended_hours"`
+	RatioQty             *decimal.Decimal      `json:"ratio_qty"`
+	Legs                 []Order               `json:"legs"`
+	AdvancedInstructions *AdvancedInstructions `json:"advanced_instructions,omitempty"`
 }
 
 //easyjson:json
@@ -252,6 +253,51 @@ const (
 	GTD TimeInForce = "gtd"
 	CLS TimeInForce = "cls"
 )
+
+// Algorithm represents the advanced routing algorithm for Elite Smart Router orders.
+// See: https://docs.alpaca.markets/docs/alpaca-elite-smart-router
+type Algorithm string
+
+const (
+	// AlgorithmDMA is Direct Market Access - orders are routed directly to the specified exchange.
+	AlgorithmDMA Algorithm = "DMA"
+	// AlgorithmTWAP is Time-Weighted Average Price - executes orders evenly over a specified time period.
+	AlgorithmTWAP Algorithm = "TWAP"
+	// AlgorithmVWAP is Volume-Weighted Average Price - executes orders in proportion to market volume.
+	AlgorithmVWAP Algorithm = "VWAP"
+)
+
+// Destination represents the target exchange for DMA order execution.
+type Destination string
+
+const (
+	DestinationNYSE   Destination = "NYSE"
+	DestinationNASDAQ Destination = "NASDAQ"
+	DestinationARCA   Destination = "ARCA"
+)
+
+// AdvancedInstructions contains advanced routing instructions for Elite Smart Router orders.
+// These instructions enable DMA (Direct Market Access), TWAP (Time-Weighted Average Price),
+// and VWAP (Volume-Weighted Average Price) order execution strategies.
+type AdvancedInstructions struct {
+	// Algorithm specifies the advanced routing algorithm to use (DMA, TWAP, or VWAP).
+	Algorithm Algorithm `json:"algorithm,omitempty"`
+	// Destination is the target exchange for DMA orders (NYSE, NASDAQ, or ARCA).
+	Destination Destination `json:"destination,omitempty"`
+	// DisplayQty is the maximum shares/contracts displayed on the exchange at any time.
+	// Must be in round lot increments. Used for iceberg/reserve orders.
+	DisplayQty *decimal.Decimal `json:"display_qty,omitempty"`
+	// StartTime is when the algorithm should start executing.
+	// Must be within current market trading hours. Used for TWAP/VWAP orders.
+	StartTime *time.Time `json:"start_time,omitempty"`
+	// EndTime is when the algorithm should finish executing.
+	// Must be within current market trading hours. Used for TWAP/VWAP orders.
+	EndTime *time.Time `json:"end_time,omitempty"`
+	// MaxPercentage is the maximum percentage of the ticker's period volume this order
+	// may participate in. Must be 0 < max_percentage < 1, with up to 3 decimal points precision.
+	// Used for TWAP/VWAP orders.
+	MaxPercentage *decimal.Decimal `json:"max_percentage,omitempty"`
+}
 
 type DTBPCheck string
 

--- a/alpaca/entities_easyjson.go
+++ b/alpaca/entities_easyjson.go
@@ -2039,6 +2039,16 @@ func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca16(in *jlexe
 				}
 				in.Delim(']')
 			}
+		case "advanced_instructions":
+			if in.IsNull() {
+				in.Skip()
+				out.AdvancedInstructions = nil
+			} else {
+				if out.AdvancedInstructions == nil {
+					out.AdvancedInstructions = new(AdvancedInstructions)
+				}
+				(*out.AdvancedInstructions).UnmarshalEasyJSON(in)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -2292,6 +2302,11 @@ func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca16(out *jwri
 			}
 			out.RawByte(']')
 		}
+	}
+	if in.AdvancedInstructions != nil {
+		const prefix string = ",\"advanced_instructions\":"
+		out.RawString(prefix)
+		(*in.AdvancedInstructions).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -3352,7 +3367,174 @@ func (v *Announcement) UnmarshalJSON(data []byte) error {
 func (v *Announcement) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca23(l, v)
 }
-func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(in *jlexer.Lexer, out *AddSymbolToWatchlistRequest) {
+func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(in *jlexer.Lexer, out *AdvancedInstructions) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "algorithm":
+			out.Algorithm = Algorithm(in.String())
+		case "destination":
+			out.Destination = Destination(in.String())
+		case "display_qty":
+			if in.IsNull() {
+				in.Skip()
+				out.DisplayQty = nil
+			} else {
+				if out.DisplayQty == nil {
+					out.DisplayQty = new(decimal.Decimal)
+				}
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.DisplayQty).UnmarshalJSON(data))
+				}
+			}
+		case "start_time":
+			if in.IsNull() {
+				in.Skip()
+				out.StartTime = nil
+			} else {
+				if out.StartTime == nil {
+					out.StartTime = new(time.Time)
+				}
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.StartTime).UnmarshalJSON(data))
+				}
+			}
+		case "end_time":
+			if in.IsNull() {
+				in.Skip()
+				out.EndTime = nil
+			} else {
+				if out.EndTime == nil {
+					out.EndTime = new(time.Time)
+				}
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.EndTime).UnmarshalJSON(data))
+				}
+			}
+		case "max_percentage":
+			if in.IsNull() {
+				in.Skip()
+				out.MaxPercentage = nil
+			} else {
+				if out.MaxPercentage == nil {
+					out.MaxPercentage = new(decimal.Decimal)
+				}
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.MaxPercentage).UnmarshalJSON(data))
+				}
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(out *jwriter.Writer, in AdvancedInstructions) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.Algorithm != "" {
+		const prefix string = ",\"algorithm\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.String(string(in.Algorithm))
+	}
+	if in.Destination != "" {
+		const prefix string = ",\"destination\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Destination))
+	}
+	if in.DisplayQty != nil {
+		const prefix string = ",\"display_qty\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Raw((*in.DisplayQty).MarshalJSON())
+	}
+	if in.StartTime != nil {
+		const prefix string = ",\"start_time\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Raw((*in.StartTime).MarshalJSON())
+	}
+	if in.EndTime != nil {
+		const prefix string = ",\"end_time\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Raw((*in.EndTime).MarshalJSON())
+	}
+	if in.MaxPercentage != nil {
+		const prefix string = ",\"max_percentage\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Raw((*in.MaxPercentage).MarshalJSON())
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v AdvancedInstructions) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v AdvancedInstructions) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *AdvancedInstructions) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *AdvancedInstructions) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(l, v)
+}
+func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(in *jlexer.Lexer, out *AddSymbolToWatchlistRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3383,7 +3565,7 @@ func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(out *jwriter.Writer, in AddSymbolToWatchlistRequest) {
+func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(out *jwriter.Writer, in AddSymbolToWatchlistRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3398,27 +3580,27 @@ func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(out *jwri
 // MarshalJSON supports json.Marshaler interface
 func (v AddSymbolToWatchlistRequest) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(&w, v)
+	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AddSymbolToWatchlistRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(w, v)
+	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *AddSymbolToWatchlistRequest) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(&r, v)
+	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AddSymbolToWatchlistRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca24(l, v)
+	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(l, v)
 }
-func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(in *jlexer.Lexer, out *AccountConfigurations) {
+func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(in *jlexer.Lexer, out *AccountConfigurations) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3455,7 +3637,7 @@ func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(out *jwriter.Writer, in AccountConfigurations) {
+func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(out *jwriter.Writer, in AccountConfigurations) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3485,27 +3667,27 @@ func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(out *jwri
 // MarshalJSON supports json.Marshaler interface
 func (v AccountConfigurations) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(&w, v)
+	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AccountConfigurations) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(w, v)
+	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *AccountConfigurations) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(&r, v)
+	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AccountConfigurations) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca25(l, v)
+	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(l, v)
 }
-func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(in *jlexer.Lexer, out *AccountActivity) {
+func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(in *jlexer.Lexer, out *AccountActivity) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3584,7 +3766,7 @@ func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(out *jwriter.Writer, in AccountActivity) {
+func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(out *jwriter.Writer, in AccountActivity) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3679,27 +3861,27 @@ func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(out *jwri
 // MarshalJSON supports json.Marshaler interface
 func (v AccountActivity) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(&w, v)
+	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AccountActivity) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(w, v)
+	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *AccountActivity) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(&r, v)
+	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AccountActivity) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca26(l, v)
+	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(l, v)
 }
-func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(in *jlexer.Lexer, out *Account) {
+func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(in *jlexer.Lexer, out *Account) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3834,7 +4016,7 @@ func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(out *jwriter.Writer, in Account) {
+func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(out *jwriter.Writer, in Account) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4009,27 +4191,27 @@ func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(out *jwri
 // MarshalJSON supports json.Marshaler interface
 func (v Account) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(&w, v)
+	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Account) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(w, v)
+	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *Account) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(&r, v)
+	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Account) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca27(l, v)
+	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(l, v)
 }
-func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(in *jlexer.Lexer, out *APIError) {
+func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca29(in *jlexer.Lexer, out *APIError) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4062,7 +4244,7 @@ func easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(out *jwriter.Writer, in APIError) {
+func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca29(out *jwriter.Writer, in APIError) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4087,23 +4269,23 @@ func easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(out *jwri
 // MarshalJSON supports json.Marshaler interface
 func (v APIError) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(&w, v)
+	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca29(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v APIError) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(w, v)
+	easyjson3e8ab7adEncodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca29(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *APIError) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(&r, v)
+	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca29(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *APIError) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca28(l, v)
+	easyjson3e8ab7adDecodeGithubComAlpacahqAlpacaTradeApiGoV3Alpaca29(l, v)
 }

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -559,8 +559,8 @@ type PlaceOrderRequest struct {
 	TrailPrice           *decimal.Decimal      `json:"trail_price"`
 	TrailPercent         *decimal.Decimal      `json:"trail_percent"`
 	PositionIntent       PositionIntent        `json:"position_intent,omitempty"`
-	Legs                 []Leg                 `json:"legs"`                          // mleg order legs
-	AdvancedInstructions *AdvancedInstructions `json:"advanced_instructions,omitempty"` // Elite Smart Router instructions (DMA, TWAP, VWAP)
+	Legs                 []Leg                 `json:"legs"`                            // mleg order legs
+	AdvancedInstructions *AdvancedInstructions `json:"advanced_instructions,omitempty"` // DMA, TWAP, VWAP
 }
 
 type TakeProfit struct {

--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -543,23 +543,24 @@ type Leg struct {
 }
 
 type PlaceOrderRequest struct {
-	Symbol         string           `json:"symbol"`
-	Qty            *decimal.Decimal `json:"qty"`
-	Notional       *decimal.Decimal `json:"notional"`
-	Side           Side             `json:"side"`
-	Type           OrderType        `json:"type"`
-	TimeInForce    TimeInForce      `json:"time_in_force"`
-	LimitPrice     *decimal.Decimal `json:"limit_price"`
-	ExtendedHours  bool             `json:"extended_hours"`
-	StopPrice      *decimal.Decimal `json:"stop_price"`
-	ClientOrderID  string           `json:"client_order_id"`
-	OrderClass     OrderClass       `json:"order_class"`
-	TakeProfit     *TakeProfit      `json:"take_profit"`
-	StopLoss       *StopLoss        `json:"stop_loss"`
-	TrailPrice     *decimal.Decimal `json:"trail_price"`
-	TrailPercent   *decimal.Decimal `json:"trail_percent"`
-	PositionIntent PositionIntent   `json:"position_intent,omitempty"`
-	Legs           []Leg            `json:"legs"` // mleg order legs
+	Symbol               string                `json:"symbol"`
+	Qty                  *decimal.Decimal      `json:"qty"`
+	Notional             *decimal.Decimal      `json:"notional"`
+	Side                 Side                  `json:"side"`
+	Type                 OrderType             `json:"type"`
+	TimeInForce          TimeInForce           `json:"time_in_force"`
+	LimitPrice           *decimal.Decimal      `json:"limit_price"`
+	ExtendedHours        bool                  `json:"extended_hours"`
+	StopPrice            *decimal.Decimal      `json:"stop_price"`
+	ClientOrderID        string                `json:"client_order_id"`
+	OrderClass           OrderClass            `json:"order_class"`
+	TakeProfit           *TakeProfit           `json:"take_profit"`
+	StopLoss             *StopLoss             `json:"stop_loss"`
+	TrailPrice           *decimal.Decimal      `json:"trail_price"`
+	TrailPercent         *decimal.Decimal      `json:"trail_percent"`
+	PositionIntent       PositionIntent        `json:"position_intent,omitempty"`
+	Legs                 []Leg                 `json:"legs"`                          // mleg order legs
+	AdvancedInstructions *AdvancedInstructions `json:"advanced_instructions,omitempty"` // Elite Smart Router instructions (DMA, TWAP, VWAP)
 }
 
 type TakeProfit struct {


### PR DESCRIPTION
This commit adds support for Alpaca's Elite Smart Router advanced order instructions, enabling:

- DMA (Direct Market Access) orders with exchange destination routing
- TWAP (Time-Weighted Average Price) algorithmic execution
- VWAP (Volume-Weighted Average Price) algorithmic execution
- Iceberg/reserve orders via display_qty parameter
- Time-bounded execution via start_time/end_time parameters
- Volume participation limits via max_percentage parameter

New types added:
- Algorithm: DMA, TWAP, VWAP enum
- Destination: NYSE, NASDAQ, ARCA enum
- AdvancedInstructions: struct with all advanced routing fields

Updated:
- Order struct: added AdvancedInstructions field
- PlaceOrderRequest: added AdvancedInstructions field
- README: added documentation and examples
- Tests: added comprehensive test coverage

Ref: https://docs.alpaca.markets/docs/alpaca-elite-smart-router