### PR TITLE
fix: prevent Response body leak on retries

### DIFF
--- a/alpaca/rest.go
+++ b/alpaca/rest.go
@@ -111,6 +111,7 @@ func defaultDo(c *Client, req *http.Request) (*http.Response, error) {
 		if i >= c.opts.RetryLimit {
 			break
 		}
+		closeResp(resp)
 		time.Sleep(c.opts.RetryDelay)
 	}
 

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -83,16 +83,34 @@ func TestDefaultDo_SuccessfulRetries(t *testing.T) {
 		}
 		fmt.Fprint(w, "success")
 	}))
+	defer ts.Close()
+
+	tracker := &trackingTransport{wrapped: http.DefaultTransport}
+
 	c := NewClient(ClientOpts{
 		RetryDelay: time.Nanosecond,
+		HTTPClient: &http.Client{Transport: tracker},
 	})
+
 	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
 	require.NoError(t, err)
+
 	resp, err := defaultDo(c, req)
 	require.NoError(t, err)
+
 	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
+
 	assert.Equal(t, "success", string(b))
+
+	// Should have 4 bodies: 3 retries + 1 success
+	require.Len(t, tracker.bodies, 4)
+
+	// The first 3 (429 responses) should have been closed and drained
+	for i := 0; i < 3; i++ {
+		assert.True(t, tracker.bodies[i].closed, "body %d should be closed", i)
+		assert.True(t, tracker.bodies[i].drained, "body %d should be drained", i)
+	}
 }
 
 func TestDefaultDo_TooManyRetries(t *testing.T) {
@@ -1347,4 +1365,39 @@ func (nopCloser) Close() error { return nil }
 func genBody(data interface{}) io.ReadCloser {
 	buf, _ := json.Marshal(data)
 	return nopCloser{bytes.NewBuffer(buf)}
+}
+
+type trackingBody struct {
+    io.ReadCloser
+    closed bool
+    drained bool
+}
+
+func (tb *trackingBody) Read(p []byte) (int, error) {
+    n, err := tb.ReadCloser.Read(p)
+    if err == io.EOF {
+        tb.drained = true
+    }
+    return n, err
+}
+
+func (tb *trackingBody) Close() error {
+    tb.closed = true
+    return tb.ReadCloser.Close()
+}
+
+type trackingTransport struct {
+    bodies  []*trackingBody
+    wrapped http.RoundTripper
+}
+
+func (t *trackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+    resp, err := t.wrapped.RoundTrip(req)
+    if err != nil {
+        return nil, err
+    }
+    tb := &trackingBody{ReadCloser: resp.Body}
+    t.bodies = append(t.bodies, tb)
+    resp.Body = tb
+    return resp, nil
 }

--- a/alpaca/rest_test.go
+++ b/alpaca/rest_test.go
@@ -107,9 +107,9 @@ func TestDefaultDo_SuccessfulRetries(t *testing.T) {
 	require.Len(t, tracker.bodies, 4)
 
 	// The first 3 (429 responses) should have been closed and drained
-	for i := 0; i < 3; i++ {
-		assert.True(t, tracker.bodies[i].closed, "body %d should be closed", i)
-		assert.True(t, tracker.bodies[i].drained, "body %d should be drained", i)
+	for j := 0; j < 3; j++ {
+		assert.True(t, tracker.bodies[j].closed, "body %d should be closed", j)
+		assert.True(t, tracker.bodies[j].drained, "body %d should be drained", j)
 	}
 }
 
@@ -1368,36 +1368,36 @@ func genBody(data interface{}) io.ReadCloser {
 }
 
 type trackingBody struct {
-    io.ReadCloser
-    closed bool
-    drained bool
+	io.ReadCloser
+	closed  bool
+	drained bool
 }
 
 func (tb *trackingBody) Read(p []byte) (int, error) {
-    n, err := tb.ReadCloser.Read(p)
-    if err == io.EOF {
-        tb.drained = true
-    }
-    return n, err
+	n, err := tb.ReadCloser.Read(p)
+	if err == io.EOF {
+		tb.drained = true
+	}
+	return n, err
 }
 
 func (tb *trackingBody) Close() error {
-    tb.closed = true
-    return tb.ReadCloser.Close()
+	tb.closed = true
+	return tb.ReadCloser.Close()
 }
 
 type trackingTransport struct {
-    bodies  []*trackingBody
-    wrapped http.RoundTripper
+	bodies  []*trackingBody
+	wrapped http.RoundTripper
 }
 
 func (t *trackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-    resp, err := t.wrapped.RoundTrip(req)
-    if err != nil {
-        return nil, err
-    }
-    tb := &trackingBody{ReadCloser: resp.Body}
-    t.bodies = append(t.bodies, tb)
-    resp.Body = tb
-    return resp, nil
+	resp, err := t.wrapped.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	tb := &trackingBody{ReadCloser: resp.Body}
+	t.bodies = append(t.bodies, tb)
+	resp.Body = tb
+	return resp, nil
 }

--- a/marketdata/rest.go
+++ b/marketdata/rest.go
@@ -126,6 +126,7 @@ RetryLoop:
 		if i >= c.opts.RetryLimit {
 			break
 		}
+		closeResp(resp)
 		time.Sleep(c.opts.RetryDelay)
 	}
 

--- a/marketdata/rest_test.go
+++ b/marketdata/rest_test.go
@@ -59,14 +59,23 @@ func TestDefaultDo_Retry(t *testing.T) {
 		tryCount++
 	}))
 	defer server.Close()
+
+	tracker := &trackingTransport{wrapped: http.DefaultTransport}
+
 	client := NewClient(ClientOpts{
 		BaseURL:    server.URL,
 		RetryDelay: time.Nanosecond,
 		RetryLimit: 5,
+		HTTPClient: &http.Client{Transport: tracker},
 	})
 	bar, err := client.GetLatestBar("SPY", GetLatestBarRequest{})
 	require.NoError(t, err)
 	assert.Equal(t, 469.18, bar.High)
+
+	for i := 0; i < 3; i++ {
+		assert.True(t, tracker.bodies[i].closed, "body %d should be closed", i)
+		assert.True(t, tracker.bodies[i].drained, "body %d should be drained", i)
+	}
 }
 
 func TestDefaultDo_TooMany429s(t *testing.T) {
@@ -1526,4 +1535,39 @@ func TestGetLatestCryptoPerpPricing(t *testing.T) {
 		Timestamp:       time.Date(2024, 12, 19, 9, 33, 36, 311000000, time.UTC),
 		NextFundingTime: time.Date(2024, 12, 19, 10, 33, 36, 311000000, time.UTC),
 	}, *got)
+}
+
+type trackingBody struct {
+    io.ReadCloser
+    closed bool
+    drained bool
+}
+
+func (tb *trackingBody) Read(p []byte) (int, error) {
+    n, err := tb.ReadCloser.Read(p)
+    if err == io.EOF {
+        tb.drained = true
+    }
+    return n, err
+}
+
+func (tb *trackingBody) Close() error {
+    tb.closed = true
+    return tb.ReadCloser.Close()
+}
+
+type trackingTransport struct {
+    bodies  []*trackingBody
+    wrapped http.RoundTripper
+}
+
+func (t *trackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+    resp, err := t.wrapped.RoundTrip(req)
+    if err != nil {
+        return nil, err
+    }
+    tb := &trackingBody{ReadCloser: resp.Body}
+    t.bodies = append(t.bodies, tb)
+    resp.Body = tb
+    return resp, nil
 }

--- a/marketdata/rest_test.go
+++ b/marketdata/rest_test.go
@@ -1538,36 +1538,36 @@ func TestGetLatestCryptoPerpPricing(t *testing.T) {
 }
 
 type trackingBody struct {
-    io.ReadCloser
-    closed bool
-    drained bool
+	io.ReadCloser
+	closed  bool
+	drained bool
 }
 
 func (tb *trackingBody) Read(p []byte) (int, error) {
-    n, err := tb.ReadCloser.Read(p)
-    if err == io.EOF {
-        tb.drained = true
-    }
-    return n, err
+	n, err := tb.ReadCloser.Read(p)
+	if err == io.EOF {
+		tb.drained = true
+	}
+	return n, err
 }
 
 func (tb *trackingBody) Close() error {
-    tb.closed = true
-    return tb.ReadCloser.Close()
+	tb.closed = true
+	return tb.ReadCloser.Close()
 }
 
 type trackingTransport struct {
-    bodies  []*trackingBody
-    wrapped http.RoundTripper
+	bodies  []*trackingBody
+	wrapped http.RoundTripper
 }
 
 func (t *trackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-    resp, err := t.wrapped.RoundTrip(req)
-    if err != nil {
-        return nil, err
-    }
-    tb := &trackingBody{ReadCloser: resp.Body}
-    t.bodies = append(t.bodies, tb)
-    resp.Body = tb
-    return resp, nil
+	resp, err := t.wrapped.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	tb := &trackingBody{ReadCloser: resp.Body}
+	t.bodies = append(t.bodies, tb)
+	resp.Body = tb
+	return resp, nil
 }


### PR DESCRIPTION
the resp Body isn't closed between replies. Probably harmless but better safe than sorry.

Issue was originally mentioned here: https://github.com/alpacahq/alpaca-trade-api-go/issues/307

For the tests I used AI to help find a way to verify each retry was closed and flushed.
